### PR TITLE
Improve Release and Pcakaging process

### DIFF
--- a/Jenkinsfile.d/package
+++ b/Jenkinsfile.d/package
@@ -51,8 +51,8 @@ pipeline {
     BRAND                 = 'jenkins.mk'
     CREDENTIAL            = 'credentials/test.mk'
     GPG_FILE              = 'gpg-test-jenkins-release.gpg'
-    GPG_KEYNAME           = 'test-jenkins-release' \\ Used from jenkins-infra/release
-    GPG_KEYRING           = "$GPG_FILE" \\ Used from jenkinsci/packaging
+    GPG_KEYNAME           = 'test-jenkins-release' // Used from jenkins-infra/release
+    GPG_KEYRING           = "$GPG_FILE" // Used from jenkinsci/packaging
     GPG_PASSPHRASE        = credentials('release-gpg-passphrase')
     GPG_PASSPHRASE_FILE   = "$WORKSPACE/gpg.password.txt" // Used from jenkinsci/packaging
     WAR_FILENAME          = 'jenkins.war'

--- a/Jenkinsfile.d/package
+++ b/Jenkinsfile.d/package
@@ -95,62 +95,117 @@ pipeline {
         }
       }
     }
-    stage('Build'){
+    stage('Package'){
       failFast false
       parallel {
         stage('Debian') {
-          steps {
-            container('packaging'){
-              sh 'make deb'
-              writeFile file: "$GPG_PASSPHRASE_FILE", text: "$GPG_PASSPHRASE"
-              sh 'make -e "GPG_KEYRING=$GPG_KEYRING" -e "GPG_PASSPHRASE_FILE=$GPG_PASSPHRASE_FILE" deb.publish'
-              archiveArtifacts artifacts: "target/debian/*.deb"
+          stages {
+            stage('Build'){
+              steps {
+                container('packaging'){
+                  sh 'make deb'
+                  archiveArtifacts artifacts: "target/debian/*.deb"
+                }
+              }
+            }
+            stage('Publish'){
+              steps {
+                container('packaging'){
+                  writeFile file: "$GPG_PASSPHRASE_FILE", text: "$GPG_PASSPHRASE"
+                  sh '''\
+                    make \
+                      -e \\"GPG_KEYRING=$GPG_KEYRING\\" \
+                      -e \\"GPG_PASSPHRASE_FILE=$GPG_PASSPHRASE_FILE\\" \
+                      deb.publish'
+                  '''
+                }
+              }
             }
           }
         }
         stage('Redhat') {
-          steps {
-            container('packaging'){
-              sh 'make rpm'
-              writeFile file: "$GPG_PASSPHRASE_FILE", text: "$GPG_PASSPHRASE"
-              sh 'make -e "GPG_KEYRING=$GPG_KEYRING" -e "GPG_PASSPHRASE_FILE=$GPG_PASSPHRASE_FILE" rpm.publish'
-              archiveArtifacts artifacts: "target/rpm/*.rpm"
+          stages {
+            stage('Build'){
+              steps {
+                container('packaging'){
+                  sh 'make rpm'
+                  archiveArtifacts artifacts: "target/rpm/*.rpm"
+                }
+              }
+            }
+            stage('Publish'){
+              steps {
+                container('packaging'){
+                  writeFile file: "$GPG_PASSPHRASE_FILE", text: "$GPG_PASSPHRASE"
+                  sh '''\
+                    make \
+                      -e \\"GPG_KEYRING=$GPG_KEYRING\\" \
+                      -e \\"GPG_PASSPHRASE_FILE=$GPG_PASSPHRASE_FILE\\" \
+                      rpm.publish'
+                  '''
+                }
+              }
             }
           }
         }
         stage('Suse') {
-          steps {
-            container('packaging'){
-              sh 'make suse'
-              writeFile file: "$GPG_PASSPHRASE_FILE", text: "$GPG_PASSPHRASE"
-              sh 'make -e "GPG_KEYRING=$GPG_KEYRING" -e "GPG_PASSPHRASE_FILE=$GPG_PASSPHRASE_FILE" suse.publish'
-              archiveArtifacts artifacts: "target/suse/*.rpm"
+          stages {
+            stage('Build'){
+              steps {
+                container('packaging'){
+                  sh 'make suse'
+                  writeFile file: "$GPG_PASSPHRASE_FILE", text: "$GPG_PASSPHRASE"
+                  sh 'make -e "GPG_KEYRING=$GPG_KEYRING" -e "GPG_PASSPHRASE_FILE=$GPG_PASSPHRASE_FILE" suse.publish'
+                  archiveArtifacts artifacts: "target/suse/*.rpm"
+                }
+              }
+            }
+            stage('Publish'){
+              steps {
+                container('packaging'){
+                  writeFile file: "$GPG_PASSPHRASE_FILE", text: "$GPG_PASSPHRASE"
+                  sh '''\
+                    make \
+                      -e \\"GPG_KEYRING=$GPG_KEYRING\\" \
+                      -e \\"GPG_PASSPHRASE_FILE=$GPG_PASSPHRASE_FILE\\" \
+                      suse.publish'
+                  '''
+                }
+              }
             }
           }
         }
         stage('Windows') {
+          // Windows requirement: Every steps need to be executed inside default jnlp 
+          // as the step 'container' is knowned to not be working
           agent {
             kubernetes {
               label 'packaging-windows'
               yamlFile 'PodTemplates.d/package-windows'
             }
           }
-          // Windows requirement: Every steps need to be executed inside default jnlp 
-          // as the step 'container' is knowned to not be working
-          steps {
-            git branch: 'master', credentialsId: 'release-key', url: 'git@github.com:olblak/packaging.git'
-            dir ('release'){
-              checkout scm
-            }
+          stages {
+            stage('Build'){
+              steps {
+                git branch: 'master', credentialsId: 'release-key', url: 'git@github.com:olblak/packaging.git'
+                dir ('release'){
+                  checkout scm
+                }
 
-            unstash 'GPG'
-            unstash 'WAR'
-            bat '''
-              $env:WAR = \'C:\\home\\jenkins\\agent\\workspace\\core-package_master\\jenkins.war\'
-              powershell -File C:\\home\\jenkins\\agent\\workspace\\core-package_master\\make.ps1
-            '''
-            archiveArtifacts 'msi\\build\\bin\\Release\\en-US\\*.msi'
-            archiveArtifacts 'msi\\build\\bin\\Release\\en-US\\*.msi.sha256'
+                unstash 'GPG'
+                unstash 'WAR'
+                bat '''
+                  $env:WAR = \'C:\\home\\jenkins\\agent\\workspace\\core-package_master\\jenkins.war\'
+                  powershell -File C:\\home\\jenkins\\agent\\workspace\\core-package_master\\make.ps1
+                '''
+                archiveArtifacts 'msi\\build\\bin\\Release\\en-US\\*.msi'
+                archiveArtifacts 'msi\\build\\bin\\Release\\en-US\\*.msi.sha256'
+              }
+            }
+            //stage('Publish'){
+            //  steps {
+            //  }
+            //}
           }
         }
       }

--- a/Jenkinsfile.d/package
+++ b/Jenkinsfile.d/package
@@ -51,9 +51,10 @@ pipeline {
     BRAND                 = 'jenkins.mk'
     CREDENTIAL            = 'credentials/test.mk'
     GPG_FILE              = 'gpg-test-jenkins-release.gpg'
-    GPG_KEYNAME           = 'test-jenkins-release'
+    GPG_KEYNAME           = 'test-jenkins-release' \\ Used from jenkins-infra/release
+    GPG_KEYRING           = "$GPG_FILE" \\ Used from jenkinsci/packaging
     GPG_PASSPHRASE        = credentials('release-gpg-passphrase')
-    GPG_PASSPHRASE_FILE   = "$WORKSPACE/gpg.password.txt"
+    GPG_PASSPHRASE_FILE   = "$WORKSPACE/gpg.password.txt" // Used from jenkinsci/packaging
     WAR_FILENAME          = 'jenkins.war'
     WAR                   = "$WORKSPACE/$WAR_FILENAME"
   }
@@ -101,7 +102,11 @@ pipeline {
           steps {
             container('packaging'){
               sh 'make deb'
-              sh 'make deb.publish'
+              sh '''
+                echo $GPG_PASSPHRASE > $GPG_PASSPHRASE_FILE
+                make deb.publish'
+                rm $GPG_PASSPHRASE_FILE
+              '''
               archiveArtifacts artifacts: "target/debian/*.deb"
             }
           }
@@ -110,7 +115,11 @@ pipeline {
           steps {
             container('packaging'){
               sh 'make rpm'
-              sh 'make rpm.publish'
+              sh '''
+                echo $GPG_PASSPHRASE > $GPG_PASSPHRASE_FILE
+                make rpm.publish
+                rm  $GPG_PASSPHRASE_FILE
+              '''
               archiveArtifacts artifacts: "target/rpm/*.rpm"
             }
           }
@@ -119,7 +128,11 @@ pipeline {
           steps {
             container('packaging'){
               sh 'make suse'
-              sh 'make suse.publish'
+              sh '''
+                echo $GPG_PASSPHRASE > $GPG_PASSPHRASE_FILE
+                make suse.publish'
+                rm  $GPG_PASSPHRASE_FILE
+              '''
               archiveArtifacts artifacts: "target/suse/*.rpm"
             }
           }
@@ -132,7 +145,7 @@ pipeline {
             }
           }
           // Windows requirement: Every steps need to be executed inside default jnlp 
-          // as 'container' is knowned to not be working
+          // as the step 'container' is knowned to not be working
           steps {
             git branch: 'master', credentialsId: 'release-key', url: 'git@github.com:olblak/packaging.git'
             dir ('release'){

--- a/Jenkinsfile.d/package
+++ b/Jenkinsfile.d/package
@@ -208,9 +208,4 @@ pipeline {
       }
     }
   }
-  post {
-    failure {
-      input 'Can we proceed?'
-    }
-  }
 }

--- a/Jenkinsfile.d/package
+++ b/Jenkinsfile.d/package
@@ -116,7 +116,7 @@ pipeline {
                     make \
                       -e \\"GPG_KEYRING=$GPG_KEYRING\\" \
                       -e \\"GPG_PASSPHRASE_FILE=$GPG_PASSPHRASE_FILE\\" \
-                      deb.publish'
+                      deb.publish
                   '''
                 }
               }
@@ -141,7 +141,7 @@ pipeline {
                     make \
                       -e \\"GPG_KEYRING=$GPG_KEYRING\\" \
                       -e \\"GPG_PASSPHRASE_FILE=$GPG_PASSPHRASE_FILE\\" \
-                      rpm.publish'
+                      rpm.publish
                   '''
                 }
               }
@@ -168,7 +168,7 @@ pipeline {
                     make \
                       -e \\"GPG_KEYRING=$GPG_KEYRING\\" \
                       -e \\"GPG_PASSPHRASE_FILE=$GPG_PASSPHRASE_FILE\\" \
-                      suse.publish'
+                      suse.publish
                   '''
                 }
               }

--- a/Jenkinsfile.d/package
+++ b/Jenkinsfile.d/package
@@ -46,10 +46,9 @@ pipeline {
 //    <version>: where version represent any valid existing version like 2.176.2
 
   environment {
-    BUILDENV              = 'env/test.mk'
-    BRANDING_DIR          = 'branding'
-    BRAND                 = 'jenkins.mk'
-    CREDENTIAL            = 'credentials/test.mk'
+    BUILDENV              = './env/test.mk'
+    BRAND                 = "./branding/jenkins.mk"
+    CREDENTIAL            = './credentials/test.mk'
     GPG_FILE              = 'gpg-test-jenkins-release.gpg'
     GPG_KEYNAME           = 'test-jenkins-release' // Used from jenkins-infra/release
     GPG_KEYRING           = "$GPG_FILE" // Used from jenkinsci/packaging

--- a/Jenkinsfile.d/package
+++ b/Jenkinsfile.d/package
@@ -102,11 +102,8 @@ pipeline {
           steps {
             container('packaging'){
               sh 'make deb'
-              sh '''
-                echo $GPG_PASSPHRASE > $GPG_PASSPHRASE_FILE
-                make deb.publish'
-                rm $GPG_PASSPHRASE_FILE
-              '''
+              writeFile file: "$GPG_PASSPHRASE_FILE", text: "$GPG_PASSPHRASE"
+              sh 'make -e "GPG_KEYRING=$GPG_KEYRING" -e "GPG_PASSPHRASE_FILE=$GPG_PASSPHRASE_FILE" deb.publish'
               archiveArtifacts artifacts: "target/debian/*.deb"
             }
           }
@@ -115,11 +112,8 @@ pipeline {
           steps {
             container('packaging'){
               sh 'make rpm'
-              sh '''
-                echo $GPG_PASSPHRASE > $GPG_PASSPHRASE_FILE
-                make rpm.publish
-                rm  $GPG_PASSPHRASE_FILE
-              '''
+              writeFile file: "$GPG_PASSPHRASE_FILE", text: "$GPG_PASSPHRASE"
+              sh 'make -e "GPG_KEYRING=$GPG_KEYRING" -e "GPG_PASSPHRASE_FILE=$GPG_PASSPHRASE_FILE" rpm.publish'
               archiveArtifacts artifacts: "target/rpm/*.rpm"
             }
           }
@@ -128,11 +122,8 @@ pipeline {
           steps {
             container('packaging'){
               sh 'make suse'
-              sh '''
-                echo $GPG_PASSPHRASE > $GPG_PASSPHRASE_FILE
-                make suse.publish'
-                rm  $GPG_PASSPHRASE_FILE
-              '''
+              writeFile file: "$GPG_PASSPHRASE_FILE", text: "$GPG_PASSPHRASE"
+              sh 'make -e "GPG_KEYRING=$GPG_KEYRING" -e "GPG_PASSPHRASE_FILE=$GPG_PASSPHRASE_FILE" suse.publish'
               archiveArtifacts artifacts: "target/suse/*.rpm"
             }
           }
@@ -163,6 +154,11 @@ pipeline {
           }
         }
       }
+    }
+  }
+  post {
+    failure {
+      input 'Can we proceed?'
     }
   }
 }

--- a/Jenkinsfile.d/package
+++ b/Jenkinsfile.d/package
@@ -101,6 +101,7 @@ pipeline {
           steps {
             container('packaging'){
               sh 'make deb'
+              sh 'make deb.publish'
               archiveArtifacts artifacts: "target/debian/*.deb"
             }
           }
@@ -109,6 +110,7 @@ pipeline {
           steps {
             container('packaging'){
               sh 'make rpm'
+              sh 'make rpm.publish'
               archiveArtifacts artifacts: "target/rpm/*.rpm"
             }
           }
@@ -117,6 +119,7 @@ pipeline {
           steps {
             container('packaging'){
               sh 'make suse'
+              sh 'make suse.publish'
               archiveArtifacts artifacts: "target/suse/*.rpm"
             }
           }

--- a/Jenkinsfile.d/package
+++ b/Jenkinsfile.d/package
@@ -154,8 +154,6 @@ pipeline {
               steps {
                 container('packaging'){
                   sh 'make suse'
-                  writeFile file: "$GPG_PASSPHRASE_FILE", text: "$GPG_PASSPHRASE"
-                  sh 'make -e "GPG_KEYRING=$GPG_KEYRING" -e "GPG_PASSPHRASE_FILE=$GPG_PASSPHRASE_FILE" suse.publish'
                   archiveArtifacts artifacts: "target/suse/*.rpm"
                 }
               }

--- a/Jenkinsfile.d/release
+++ b/Jenkinsfile.d/release
@@ -96,31 +96,29 @@ pipeline {
         }
       }
       stage('Push Commits') {
-        environment {
-          GIT_SSH = 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $RELEASE_SSH_KEY'
-        }
+        // environment {
+        //   GIT_SSH = 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $RELEASE_SSH_KEY'
+        // }
 
         steps {
-          // ssh has weird doesn't work when no user is associated to a uid like 1000, therefor I run git command from
+          // ssh has doesn't work when no user is associated to a uid like 1000, therefor I run git command from
           // the jnlp container.
           container('jnlp') {
             // https://github.com/jenkinsci/kubernetes-plugin/pull/331
             // therefor we use withCredentials instead of sshagent
-            // sshagent(['release-key']) {
-            //   // We want to only commit to the repository used by the jenkins job
-            //   // instead of jenkinsci/jenkins as defined in pom.xml
-            //   sh '''
-            //     release/utils/release.sh --pushCommits
-            //   '''
-            // }
-            withCredentials([sshUserPrivateKey(credentialsId: 'release-key', keyFileVariable: 'RELEASE_SSH_KEY')]) {
+            // it's fine if used from the jnlp container
+            sshagent(['release-key']) {
+              // We want to only commit to the repository used by the jenkins job
+              // instead of jenkinsci/jenkins as defined in pom.xml
               sh 'release/utils/release.sh --pushCommits'
             }
+            // withCredentials([sshUserPrivateKey(credentialsId: 'release-key', keyFileVariable: 'RELEASE_SSH_KEY')]) {
+            //   sh 'release/utils/release.sh --pushCommits'
+            // }
 
           }
         }
       }
-
       stage('Stage Release') {
         steps {
           container('maven') {

--- a/Jenkinsfile.d/release
+++ b/Jenkinsfile.d/release
@@ -103,7 +103,7 @@ pipeline {
         steps {
           // ssh has weird doesn't work when no user is associated to a uid like 1000, therefor I run git command from
           // the jnlp container.
-          container('maven') {
+          container('jnlp') {
             // https://github.com/jenkinsci/kubernetes-plugin/pull/331
             // therefor we use withCredentials instead of sshagent
             // sshagent(['release-key']) {

--- a/PodTemplates.d/package-linux
+++ b/PodTemplates.d/package-linux
@@ -26,6 +26,9 @@ spec:
       runAsUser: 1000
       runAsGroup: 1000
     tty: true
+    volumeMounts:
+      - name: core-packages
+        mountPath: /packages
   - command:
     - "cat"
     env:
@@ -46,6 +49,13 @@ spec:
       runAsUser: 1000
       runAsGroup: 1000
     tty: true
+    volumeMounts:
+      - name: core-packages
+        mountPath: /packages
   nodeSelector:
     kubernetes.io/os: "linux"
   restartPolicy: "Never"
+  volumes:
+    - name: core-packages
+      persistentVolumeClaim:
+        claimName: core-packages

--- a/PodTemplates.d/package-windows
+++ b/PodTemplates.d/package-windows
@@ -33,8 +33,15 @@ spec:
       # runAsUser: 1000
       # runAsGroup: 1000
     tty: false
+    volumeMounts:
+      - name: core-packages
+        mountPath: 'C:/Packages'
   tolerations:
     - key: "os"
       operator: "Equal"
       value: "windows"
       effect: "NoSchedule"
+  volumes:
+    - name: core-packages
+      persistentVolumeClaim:
+        claimName: core-packages


### PR DESCRIPTION
This PR introduce the following changes:
Regarding Packaging:
* We now mount s azure file storage directly inside release.ci.jenkins.io in order to generate package site metadata for debian, redhat and suse when we publish the different artifacts
* We add a new publishing step which call make *.publish for each distribution package

Regarding Release:
* We now run git commit from the jnlp container in order to use the ssh agent
