### PR TITLE
Use -War parameter

### DIFF
--- a/Jenkinsfile.d/package
+++ b/Jenkinsfile.d/package
@@ -192,8 +192,7 @@ pipeline {
                 unstash 'GPG'
                 unstash 'WAR'
                 bat '''
-                  $env:WAR = \'C:\\home\\jenkins\\agent\\workspace\\core-package_master\\jenkins.war\'
-                  powershell -File C:\\home\\jenkins\\agent\\workspace\\core-package_master\\make.ps1
+                  powershell -File C:\\home\\jenkins\\agent\\workspace\\core-package_master\\make.ps1 -War "C:\\home\\jenkins\\agent\\workspace\\core-package_master\\jenkins.war"
                 '''
                 archiveArtifacts 'msi\\build\\bin\\Release\\en-US\\*.msi'
                 archiveArtifacts 'msi\\build\\bin\\Release\\en-US\\*.msi.sha256'


### PR DESCRIPTION
make.ps1 has a -War parameter that you can use to specify the war file location. Previously, since you are using `bat` it would require you to use `set WAR <PATH_TO_WAR>` since it is running under cmd.exe (with the bat step) instead of powershell.