### PR TITLE
Move git clone operation from Jenkinsfile to utils/release.sh

### DIFF
--- a/Jenkinsfile.d/release
+++ b/Jenkinsfile.d/release
@@ -24,8 +24,7 @@ pipeline {
     }
 
     environment {
-      JENKINS_GIT_BRANCH            = 'master'
-      JENKINS_GIT_REPOSITORY        = 'git@github.com:olblak/jenkins.git'
+      RELEASE_PROFILE               = 'experimental'
       GPG_PASSPHRASE                = credentials('release-gpg-passphrase')
       MAVEN_REPOSITORY_USERNAME     = credentials('maven-repository-username')
       MAVEN_REPOSITORY_PASSWORD     = credentials('maven-repository-password')
@@ -33,13 +32,23 @@ pipeline {
     }
 
     stages {
-      stage('Clean Release') {
+      stage('Clone Jenkins Git Repository') {
         steps {
           container('maven') {
             dir ('release'){
               checkout scm
             }
-            git branch: env.JENKINS_GIT_BRANCH, credentialsId: 'release-key', url: env.JENKINS_GIT_REPOSITORY
+
+            sshagent(['release-key']) {
+              sh 'release/utils/release.sh --cloneJenkinsGitRepository'
+            }
+
+          }
+        }
+      }
+      stage('Clean Release') {
+        steps {
+          container('maven') {
             sh 'release/utils/release.sh --cleanRelease'
           }
         }

--- a/profile.d/experimental
+++ b/profile.d/experimental
@@ -1,5 +1,5 @@
 JENKINS_GIT_BRANCH=master
-JENKINS_GIT_REPOSITORY=git@github.com:jenkinsci/jenkins.git
+JENKINS_GIT_REPOSITORY=git@github.com:olblak/jenkins.git
 GIT_EMAIL=release@jenkins.io
 GIT_NAME=release-bot
 GPG_FILE=gpg-test-jenkins-release.gpg

--- a/profile.d/weekly
+++ b/profile.d/weekly
@@ -1,3 +1,5 @@
+JENKINS_GIT_BRANCH=master
+JENKINS_GIT_REPOSITORY=git@github.com:jenkinsci/jenkins.git
 GIT_EMAIL=release@jenkins.io
 GIT_NAME=release-bot
 GPG_FILE=gpg-test-jenkins-release.gpg

--- a/utils/release.sh
+++ b/utils/release.sh
@@ -235,6 +235,7 @@ function pushCommits(){
   # Ensure we use ssh credentials
   git config --get remote.origin.url
   sed -i 's#url = https://github.com/#url = git@github.com:#' .git/config
+  git pull 
   git push origin "HEAD:$JENKINS_GIT_BRANCH" "$RELEASE_SCM_TAG"
 }
 

--- a/utils/release.sh
+++ b/utils/release.sh
@@ -53,6 +53,10 @@ function clean(){
     mvn -s settings-release.xml -B --no-transfer-progress release:clean
 }
 
+function cloneJenkinsGitRepository(){
+  git clone --branch "${JENKINS_GIT_BRANCH}" "${JENKINS_GIT_REPOSITORY}"
+}
+
 function configureGit(){
   git checkout "${JENKINS_GIT_BRANCH}"
   git config --local user.email "${GIT_EMAIL}"
@@ -277,6 +281,7 @@ function main(){
     do
       case "$1" in
             --cleanRelease) echo "Clean Release" && generateSettingsXml && clean;;
+            --cloneJenkinsGitRepository) echo "Cloning Jenkins Repository" && cloneJenkinsGitRepository ;;
             --configureGPG) echo "ConfigureGPG" && configureGPG ;;
             --configureKeystore) echo "Configure Keystore" && configureKeystore ;;
             --configureGit) echo "Configure Git" && configureGit ;;


### PR DESCRIPTION
This PR allows to easily use different release profile in order to change following behavior
* Release from a different git repository than jenkinsci/jenkins
* Push generated artifacts on a different maven repository
* Use a different GPG key