### PR TITLE
Use bat file syntax for setting the environment variable

### DIFF
--- a/Jenkinsfile.d/package
+++ b/Jenkinsfile.d/package
@@ -217,8 +217,8 @@ pipeline {
                   unstash 'KEYSTORE'
 
                   bat """
-                    $env:WAR = \'C:\\home\\jenkins\\agent\\workspace\\core-package_master\\$WORKING_DIRECTORY\\jenkins.war\'
-                    powershell -File C:\\home\\jenkins\\agent\\workspace\\core-package_master\\$WORKING_DIRECTORY\\make.ps1
+                    set WAR=%CD%\\jenkins.war
+                    powershell -File %CD%\\make.ps1
                   """
                 }
               }


### PR DESCRIPTION
This uses the bat file syntax to set the WAR environment variable and uses `%CD%` for the current directory since the `dir` step is used above.