### PR TITLE
Add ssh credentials to push artifacts to pkg.jenkins.io then force a mirror sync

### DIFF
--- a/Jenkinsfile.d/package
+++ b/Jenkinsfile.d/package
@@ -113,9 +113,11 @@ pipeline {
             stage('Publish'){
               steps {
                 container('packaging'){
-                  sh '''
-                    ./utils/release.sh --packaging war.publish
-                  '''
+                  sshagent(['pkgserver']) {
+                    sh '''
+                      ./utils/release.sh --packaging war.publish
+                    '''
+                  }
                 }
               }
             }
@@ -138,9 +140,11 @@ pipeline {
             stage('Publish'){
               steps {
                 container('packaging'){
-                  sh '''
-                    ./utils/release.sh --packaging deb.publish
-                  '''
+                  sshagent(['pkgserver']) {
+                    sh '''
+                      ./utils/release.sh --packaging deb.publish
+                    '''
+                  }
                 }
               }
             }
@@ -163,9 +167,11 @@ pipeline {
             stage('Publish'){
               steps {
                 container('packaging'){
-                  sh '''
-                    ./utils/release.sh --packaging rpm.publish
-                  '''
+                  sshagent(['pkgserver']) {
+                    sh '''
+                      ./utils/release.sh --packaging rpm.publish
+                    '''
+                  }
                 }
               }
             }
@@ -188,9 +194,11 @@ pipeline {
             stage('Publish'){
               steps {
                 container('packaging'){
-                  sh '''
-                    ./utils/release.sh --packaging suse.publish
-                  '''
+                  sshagent(['pkgserver']) {
+                    sh '''
+                      ./utils/release.sh --packaging suse.publish
+                    '''
+                  }
                 }
               }
             }
@@ -226,12 +234,14 @@ pipeline {
             }
             stage('Publish'){
               steps {
-                dir (WORKING_DIRECTORY){
-                  powershell '''
-                    & .\\msi\\publish\\publish.ps1
-                  '''
-                  archiveArtifacts 'msi\\build\\bin\\Release\\en-US\\*.msi'
-                  archiveArtifacts 'msi\\build\\bin\\Release\\en-US\\*.msi.sha256'
+                sshagent(['pkgserver']) {
+                  dir (WORKING_DIRECTORY){
+                    powershell '''
+                      & .\\msi\\publish\\publish.ps1
+                    '''
+                    archiveArtifacts 'msi\\build\\bin\\Release\\en-US\\*.msi'
+                    archiveArtifacts 'msi\\build\\bin\\Release\\en-US\\*.msi.sha256'
+                  }
                 }
               }
             }

--- a/Jenkinsfile.d/package
+++ b/Jenkinsfile.d/package
@@ -249,6 +249,21 @@ pipeline {
         }
       }
     }
+    // Force mirror synchronization
+    stage('Synchronize mirror'){
+      environment {
+        PKGSERVER = "mirrorbrain@pkg.jenkins.io"
+      }
+      steps{
+        container('jnlp'){
+          sshagent(['pkgserver']) {
+            sh '''
+              ssh $PKGSERVER /srv/releases/sync.sh
+            '''
+          }
+        }
+      }
+    }
   }
     post {
       failure {

--- a/profile.d/experimental
+++ b/profile.d/experimental
@@ -12,3 +12,5 @@ SIGN_ALIAS=jenkins
 
 # PACKAGING ENV used from jenkinsci/packaging
 RELEASELINE="-experimental"
+
+BUILDENV:=$WORKSPACE/$WORKING_DIRECTORY/env/azure.mk


### PR DESCRIPTION
In order to work, this pull request requires the credential 'pkgserver' to be configured on release.ci.jenkins.io