### PR TITLE
By default don't trigger weekly release

### DIFF
--- a/utils/release.sh
+++ b/utils/release.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-: "${RELEASE_PROFILE:=weekly}"
+: "${RELEASE_PROFILE:?Release profile required}"
 
 source ""$(dirname "$(dirname "$0")")"/profile.d/$RELEASE_PROFILE"
 


### PR DESCRIPTION
The first job on release.ci.jenkins.io triggered a weekly release, fortunately enough no production credentials are currently set. Unless we specify a profile by parameter, we shouldn't trigger a release