### PR TITLE
Update release environment binary  path

### DIFF
--- a/PodTemplates.d/package-linux
+++ b/PodTemplates.d/package-linux
@@ -28,7 +28,7 @@ spec:
     tty: true
     volumeMounts:
       - name: binary-core-packages
-        mountPath: /packages/binary
+        mountPath: /srv/releases/jenkins
       - name: website-core-packages
         mountPath: /packages/web
   - command:
@@ -53,7 +53,7 @@ spec:
     tty: true
     volumeMounts:
       - name: binary-core-packages
-        mountPath: /packages/binary
+        mountPath: /srv/releases/jenkins
       - name: website-core-packages
         mountPath: /packages/web
   affinity:


### PR DESCRIPTION
This PR aligns with binary location defined from jenkinsci/packaging.
website-core-packages is probably not needed anymore but it can stay there for now