### PR TITLE
Move mirror synchronization to release.sh

### DIFF
--- a/Jenkinsfile.d/package
+++ b/Jenkinsfile.d/package
@@ -255,14 +255,11 @@ pipeline {
     }
     // Force mirror synchronization
     stage('Synchronize mirror'){
-      environment {
-        PKGSERVER = "mirrorbrain@pkg.jenkins.io"
-      }
       steps{
         container('jnlp'){
           sshagent(['pkgserver']) {
             sh '''
-              ssh $PKGSERVER /srv/releases/sync.sh
+              ./utils/release.sh --syncMirror
             '''
           }
         }

--- a/profile.d/experimental
+++ b/profile.d/experimental
@@ -14,3 +14,7 @@ SIGN_ALIAS=jenkins
 RELEASELINE="-experimental"
 
 BUILDENV=env/azure.mk
+
+# Define endpoint used to force mirror synchronization
+PKGSERVER=mirrorbrain@20.186.155.37
+PKGSERVER_SSH_OPTS="-p 22 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"


### PR DESCRIPTION
By moving this instruction to release.sh, it allows us to use profile.d, in order to have different behaviors based on profile