### PR TITLE
Don't archive full msi patch, just artifacts

### DIFF
--- a/Jenkinsfile.d/package
+++ b/Jenkinsfile.d/package
@@ -231,15 +231,18 @@ pipeline {
                     $env:WAR=(Resolve-Path .\\jenkins.war).Path
                     & .\\make.ps1
                   '''
+                  // Don't archive the full path
+                  dir('msi\\build\\bin\\Release\\en-US') {
+                    archiveArtifacts '*.msi*'
+                  }
 
-                  archiveArtifacts 'msi\\build\\bin\\Release\\en-US\\*.msi*'
                 }
               }
             }
             stage('Publish'){
               steps {
                 container('packaging') {
-                  unarchive mapping: ['**/*.msi*': MSI]
+                  unarchive mapping: ['*.msi*': WORKING_DIRECTORY]
                   sshagent(['pkgserver']) {
                     sh '''
                       ./utils/release.sh --packaging msi.publish


### PR DESCRIPTION
In the current state, we archive './msi/build/bin/Release/en-US/jenkins-2.223.msi' so when unarchive it to $MSI, instead of creating the file $WORKSPACE/release/jenkins.msi, it creates $WORKSPACE/release/jenkins.msi/msi/build/bin/Release/en-US/jenkins-2.223.msi 

What we want to have is:
$WORKSPACE/release/jenkins-${VERSION}.msi