### PR TITLE
Export variables needed for downloadJenkins war file

### DIFF
--- a/utils/getJenkinsVersion.py
+++ b/utils/getJenkinsVersion.py
@@ -1,14 +1,40 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
-import urllib2
+from urllib.request import URLError
+import urllib.request
+import base64
 import xml.etree.ElementTree as ET
 import os
 
 
+USERNAME = os.environ.get('MAVEN_REPOSITORY_USERNAME', '')
+PASSWORD = os.environ.get('MAVEN_REPOSITORY_PASSWORD', '')
+
+
+PATH = os.environ.get('WAR', '/tmp/jenkins.war')
+
+# URL = 'https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/'
+URL = os.environ.get(
+    'JENKINS_DOWNLOAD_URL',
+    'https://release.repo.jenkins.io/repository/maven-releases/org/jenkins-ci/main/jenkins-war/')
+
+
 def getJenkinsVersion(metadataUrl, version):
+
     try:
-        url = metadataUrl
-        tree = ET.parse(urllib2.urlopen(url))
+        request = urllib.request.Request(metadataUrl)
+
+        if USERNAME != "":
+            base64string = base64.b64encode(
+                bytes('%s:%s' % (USERNAME, PASSWORD), 'ascii'))
+
+            request.add_header(
+                "Authorization", "Basic %s" % base64string.decode('utf-8'))
+
+        response = urllib.request.urlopen(request)
+
+        tree = ET.parse(response)
+
         root = tree.getroot()
 
         # Search in Maven repository for latest version of Jenkins
@@ -21,62 +47,68 @@ def getJenkinsVersion(metadataUrl, version):
                 if len(version.text.split('.')) == 3:
                     result = version.text
 
-            print "Latest Stable Jenkins version detected: {}".format(result)
+            print("Latest Stable Jenkins version detected: {}".format(result))
 
         # Search in Maven repository for latest version of Jenkins
         # that satisfies X.Y which represents weekly version
         elif version == 'weekly':
             result = root.find('versioning/release').text
-            print "Latest Jenkins version detected: {}".format(result)
+            print("Latest Jenkins version detected: {}".format(result))
 
         # In this case we assume that we provided a valid version
         elif len(version.split('.')) > 0:
             result = version
-            print "Jenkins version specified: {}".format(result)
+            print("Jenkins version specified: {}".format(result))
 
         else:
-            print "Something went wrong with version: {}".format(version)
+            print("Something went wrong with version: {}".format(version))
             exit(1)
 
         return result
 
-    except urllib2.URLError as e:
+    except URLError as e:
         msg = 'Something went wrong while retrieving stable version: {}'
-        print msg.format(e)
+        print(msg.format(e))
         exit(1)
 
 
 def downloadJenkins(version):
     downloadUrl = URL + '{}/jenkins-war-{}.war'.format(version, version)
 
-    print "Downloading version {} from {} ".format(version, downloadUrl)
+    print("Downloading version {} from {} ".format(version, downloadUrl))
 
     try:
-        response = urllib2.urlopen(downloadUrl)
-        content = response.read()
+        request = urllib.request.Request(downloadUrl)
+
+        if USERNAME != "":
+            base64string = base64.b64encode(
+                bytes('%s:%s' % (USERNAME, PASSWORD), 'ascii'))
+
+            request.add_header(
+                "Authorization", "Basic %s" % base64string.decode('utf-8'))
+
+        response = urllib.request.urlopen(request)
+        content = response.read().decode(encoding='utf-8', errors='ignore')
 
         f = open(PATH, 'w')
-        f.write(content)
+        f.write(str(content))
         f.close()
-        print "War downloaded to {}".format(PATH)
+        print("War downloaded to {}".format(PATH))
 
-    except urllib2.URLError as e:
-        print type(e)
+    except URLError as e:
+        print(type(e))
         exit(1)
 
 
-# URL = 'https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/'
-URL = os.environ.get('JENKINS_DOWNLOAD_URL', 'https://release.repo.jenkins.io/repository/maven-releases/org/jenkins-ci/main/jenkins-war/')
-
-PATH = os.environ.get('WAR', '/tmp/jenkins.war')
 VERSION = getJenkinsVersion(
     URL + 'maven-metadata.xml',
     os.environ.get('JENKINS_VERSION', 'weekly')
     )
 
+
 def main():
-    print "VERSION: " + VERSION
-    print "Downloaded from: " + URL
+    print("VERSION: " + VERSION)
+    print("Downloaded from: " + URL)
     downloadJenkins(VERSION)
 
 

--- a/utils/getJenkinsVersion.py
+++ b/utils/getJenkinsVersion.py
@@ -91,7 +91,7 @@ def downloadJenkins(version):
         content = response.read().decode(encoding='utf-8', errors='ignore')
 
         f = open(PATH, 'w')
-        f.write(str(content))
+        f.write(content)
         f.close()
         print("War downloaded to {}".format(PATH))
 

--- a/utils/release.sh
+++ b/utils/release.sh
@@ -36,6 +36,17 @@ source ""$(dirname "$(dirname "$0")")"/profile.d/$RELEASE_PROFILE"
 
 : "${JENKINS_DOWNLOAD_URL:=$MAVEN_REPOSITORY_URL/$MAVEN_REPOSITORY_NAME/org/jenkins-ci/main/jenkins-war/}"
 
+export JENKINS_VERSION
+export JENKINS_DOWNLOAD_URL
+export WAR
+export BRAND
+export RELEASELINE
+export ORGANIZATION
+export BUILDENV
+export CREDENTIAL
+export GPG_PASSPHRASE_FILE
+export GPG_KEYNAME
+
 if [ ! -d "$WORKING_DIRECTORY" ]; then
   mkdir -p "$WORKING_DIRECTORY"
 fi
@@ -158,7 +169,6 @@ function downloadAzureKeyvaultSecret(){
 # * <version> represents any valid existing version like 2.176.3 available at JENKINS_DOWNLOAD_URL
 # JENKINS_DOWNLOAD_URL: Specify the endpoint to use for downloading jenkins.war 
 function downloadJenkinsWar(){
-  pwd
   "$WORKSPACE"/utils/getJenkinsVersion.py
 }
 
@@ -269,14 +279,6 @@ function configurePackagingEnv(){
   : "${BUILDENV:=$WORKSPACE/$WORKING_DIRECTORY/env/release.mk}"
   : "${CREDENTIAL:=$BRAND}" # For now, we just want this variable to be set to not empty
   : "${GPG_PASSPHRASE_FILE:=$WORKSPACE/$WORKING_DIRECTORY/$GPG_KEYNAME.pass}"
-
-  export BRAND
-  export RELEASELINE
-  export ORGANIZATION
-  export BUILDENV
-  export CREDENTIAL
-  export GPG_PASSPHRASE_FILE
-  export GPG_KEYNAME
 
 cat <<EOT> "$GPG_PASSPHRASE_FILE"
 $GPG_PASSPHRASE

--- a/utils/release.sh
+++ b/utils/release.sh
@@ -38,6 +38,8 @@ source ""$(dirname "$(dirname "$0")")"/profile.d/$RELEASE_PROFILE"
 
 export JENKINS_VERSION
 export JENKINS_DOWNLOAD_URL
+export MAVEN_REPOSITORY_USERNAME
+export MAVEN_REPOSITORY_PASSWORD
 export WAR
 export BRAND
 export RELEASELINE


### PR DESCRIPTION
Because environment variables are not exported, getJenkins.py use the default value for JENKINS_DOWNLOAD_URL which is downloading jenkins.war from local maven repository

Currently getJenkinsVersion.py is using python 2 and doesn't support basic authentication, I have a fix coming soon