### PR TITLE
Remove duplicate step

### DIFF
--- a/Jenkinsfile.d/package
+++ b/Jenkinsfile.d/package
@@ -98,7 +98,6 @@ pipeline {
     stage('Download WAR archive to package'){
       steps{
         container('packaging'){
-          sh 'utils/getJenkinsVersion.py'
           sh '''
             ./utils/release.sh --downloadJenkins
           '''


### PR DESCRIPTION
This shell command is not needed as it was replaced by the next one in order to use environment variables