### PR TITLE
Update linux pckage pod template to mount website dir in the correct location

### DIFF
--- a/PodTemplates.d/package-linux
+++ b/PodTemplates.d/package-linux
@@ -30,7 +30,7 @@ spec:
       - name: binary-core-packages
         mountPath: /srv/releases/jenkins
       - name: website-core-packages
-        mountPath: /packages/web
+        mountPath: /var/www/pkg.jenkins.io.staging/
   - command:
     - "cat"
     env:
@@ -55,7 +55,7 @@ spec:
       - name: binary-core-packages
         mountPath: /srv/releases/jenkins
       - name: website-core-packages
-        mountPath: /packages/web
+        mountPath: /var/www/pkg.jenkins.io.staging/
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
The release environment use a different directory between binaries  and pkg.jenkins.io.
