### PR TITLE
[INFRA-2619][WIP] Release component jenkinsci/remoting

### DIFF
--- a/Jenkinsfile.d/components/remoting
+++ b/Jenkinsfile.d/components/remoting
@@ -104,7 +104,7 @@ pipeline {
         steps {
           container('maven') {
             sh '''
-              utils/release.sh --stageRelease
+              utils/release.sh --performRelease
             '''
           }
         }

--- a/Jenkinsfile.d/components/remoting
+++ b/Jenkinsfile.d/components/remoting
@@ -91,25 +91,11 @@ pipeline {
         }
       }
       stage('Push Commits') {
-        // environment {
-        //   GIT_SSH = 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $RELEASE_SSH_KEY'
-        // }
-
         steps {
-          // ssh has doesn't work when no user is associated to a uid like 1000, therefor I run git command from
-          // the jnlp container.
           container('jnlp') {
-            // https://github.com/jenkinsci/kubernetes-plugin/pull/331
-            // therefor we use withCredentials instead of sshagent
-            // it's fine if used from the jnlp container
             sshagent(['release-key']) {
-              // We want to only commit to the repository used by the jenkins job
-              // instead of jenkinsci/jenkins as defined in pom.xml
               sh 'utils/release.sh --pushCommits'
             }
-            // withCredentials([sshUserPrivateKey(credentialsId: 'release-key', keyFileVariable: 'RELEASE_SSH_KEY')]) {
-            //   sh 'utils/release.sh --pushCommits'
-            // }
 
           }
         }
@@ -119,18 +105,6 @@ pipeline {
           container('maven') {
             sh '''
               utils/release.sh --stageRelease
-            '''
-          }
-        }
-      }
-      stage('Verify artifacts') {
-        steps {
-          container('maven') {
-            sh '''
-              utils/release.sh --verifyGPGSignature
-            '''
-            sh '''
-              utils/release.sh --verifyCertificateSignature
             '''
           }
         }

--- a/Jenkinsfile.d/components/remoting
+++ b/Jenkinsfile.d/components/remoting
@@ -9,7 +9,7 @@
 pipeline {
     agent {
       kubernetes {
-        label 'release-linux'
+        label 'release-component-remoting'
         yamlFile 'PodTemplates.d/release-linux.yaml'
         inheritFrom 'jnlp-linux'
       }

--- a/Jenkinsfile.d/components/remoting
+++ b/Jenkinsfile.d/components/remoting
@@ -1,0 +1,144 @@
+// -*- Groovy -*-
+
+/*
+  Jenkins Plugins:
+    * Azure-Credentials
+    * SSH-agent
+*/
+
+pipeline {
+    agent {
+      kubernetes {
+        label 'release-linux'
+        yamlFile 'PodTemplates.d/release-linux.yaml'
+        inheritFrom 'jnlp-linux'
+      }
+    }
+
+    options {
+      buildDiscarder logRotator(
+        artifactNumToKeepStr: '5',
+        numToKeepStr: '10'
+      )
+      disableConcurrentBuilds()
+    }
+
+    environment {
+      AZURE_VAULT_NAME              = 'prodreleasecore'
+      AZURE_VAULT_CERT              = 'prodreleasecore'
+      AZURE_VAULT_CLIENT_ID         = credentials('azure-vault-client-id')
+      AZURE_VAULT_CLIENT_SECRET     = credentials('azure-vault-client-secret')
+      AZURE_VAULT_TENANT_ID         = credentials('azure-vault-tenant-id')
+      GPG_PASSPHRASE                = credentials('release-gpg-passphrase')
+      GPG_FILE                      = 'jenkins-release.gpg'
+      MAVEN_REPOSITORY_USERNAME     = credentials('maven-repository-username')
+      MAVEN_REPOSITORY_PASSWORD     = credentials('maven-repository-password')
+      SIGN_STOREPASS                = credentials('signing-cert-pass')
+      RELEASE_PROFILE               = "components/remoting"
+    }
+
+    stages {
+      stage('Clone Remoting Git Repository') {
+        steps {
+          container('jnlp') {
+            sshagent(['release-key']) {
+              sh 'utils/release.sh --cloneReleaseGitRepository'
+            }
+          }
+        }
+      }
+      stage('Clean Release') {
+        steps {
+          container('maven') {
+            sh 'utils/release.sh --cleanRelease'
+          }
+        }
+      }
+      stage('Get Code Signing Certificate') {
+        steps {
+          container('azure-cli') {
+            sh '''
+              utils/release.sh --downloadAzureKeyvaultSecret
+              utils/release.sh --configureKeystore
+            '''
+          }
+        }
+      }
+      stage('Get GPG key') {
+        steps {
+          container('azure-cli') {
+            sh '''
+              utils/release.sh --getGPGKeyFromAzure
+            '''
+          }
+        }
+      }
+      stage('Prepare Release') {
+        steps {
+          container('maven') {
+            // Maven Release requires gpg key with password password and a certificate key with password
+            sh '''
+              utils/release.sh --configureGPG
+              utils/release.sh --configureGit
+              utils/release.sh --prepareRelease
+            '''
+
+            script {
+              def properties = readProperties file: 'release/release.properties'
+              env.RELEASE_SCM_TAG = properties['scm.tag']
+            }
+          }
+        }
+      }
+      stage('Push Commits') {
+        // environment {
+        //   GIT_SSH = 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $RELEASE_SSH_KEY'
+        // }
+
+        steps {
+          // ssh has doesn't work when no user is associated to a uid like 1000, therefor I run git command from
+          // the jnlp container.
+          container('jnlp') {
+            // https://github.com/jenkinsci/kubernetes-plugin/pull/331
+            // therefor we use withCredentials instead of sshagent
+            // it's fine if used from the jnlp container
+            sshagent(['release-key']) {
+              // We want to only commit to the repository used by the jenkins job
+              // instead of jenkinsci/jenkins as defined in pom.xml
+              sh 'utils/release.sh --pushCommits'
+            }
+            // withCredentials([sshUserPrivateKey(credentialsId: 'release-key', keyFileVariable: 'RELEASE_SSH_KEY')]) {
+            //   sh 'utils/release.sh --pushCommits'
+            // }
+
+          }
+        }
+      }
+      stage('Stage Release') {
+        steps {
+          container('maven') {
+            sh '''
+              utils/release.sh --stageRelease
+            '''
+          }
+        }
+      }
+      stage('Verify artifacts') {
+        steps {
+          container('maven') {
+            sh '''
+              utils/release.sh --verifyGPGSignature
+            '''
+            sh '''
+              utils/release.sh --verifyCertificateSignature
+            '''
+          }
+        }
+      }
+    }
+    post {
+      failure {
+        input '''Can I delete the pod? '''
+      }
+    }
+}

--- a/Jenkinsfile.d/release
+++ b/Jenkinsfile.d/release
@@ -47,11 +47,11 @@ pipeline {
     }
 
     stages {
-      stage('Clone Jenkins Git Repository') {
+      stage('Clone Release Git Repository') {
         steps {
           container('jnlp') {
             sshagent(['release-key']) {
-              sh 'utils/release.sh --cloneJenkinsGitRepository'
+              sh 'utils/release.sh --cloneReleaseGitRepository'
             }
           }
         }

--- a/README.adoc
+++ b/README.adoc
@@ -37,10 +37,10 @@ Those are the most important settings defined in your release profile that will 
 |===
 | Variable | Description
 
-| `JENKINS_GIT_REPOSITORY`
+| `RELEASE_GIT_REPOSITORY`
 | Defines the Jenkins git repository used by release, to release from and then push generated commits.
 
-| `JENKINS_GIT_BRANCH`
+| `RELEASE_GIT_BRANCH`
 | Defines the Jenkins branch used to checkout and then pushes commits related to the release.
 
 |`MAVEN_REPOSITORY_URL`

--- a/profile.d/components/remoting
+++ b/profile.d/components/remoting
@@ -1,0 +1,12 @@
+RELEASE_GIT_BRANCH=master
+RELEASE_GIT_REPOSITORY=git@github.com:jenkinsci/remoting.git
+GIT_EMAIL=release@jenkins.io
+GIT_NAME=release-bot
+GPG_KEYNAME="62A9756BFD780C377CF24BA8FCEF32E745F2C3D5"
+GPG_VAULT_NAME="jenkins-release-pgp"
+MAVEN_REPOSITORY_URL='https://repo.jenkins-ci.org'
+MAVEN_REPOSITORY_NAME=olblak-sandbox
+#MAVEN_REPOSITORY_NAME=releases
+#MAVEN_PUBLIC_JENKINS_REPOSITORY_MIRROR_URL='http://nexus/repository/jenkins-public/'
+MAVEN_PUBLIC_JENKINS_REPOSITORY_MIRROR_URL='https://repo.jenkins-ci.org/public/'
+SIGN_ALIAS=jenkins

--- a/profile.d/experimental
+++ b/profile.d/experimental
@@ -1,5 +1,5 @@
-JENKINS_GIT_BRANCH=master
-JENKINS_GIT_REPOSITORY=git@github.com:olblak/jenkins.git
+RELEASE_GIT_BRANCH=master
+RELEASE_GIT_REPOSITORY=git@github.com:olblak/jenkins.git
 JENKINS_VERSION=weekly
 GIT_EMAIL=release@jenkins.io
 GIT_NAME=release-bot

--- a/profile.d/stable
+++ b/profile.d/stable
@@ -1,5 +1,5 @@
-JENKINS_GIT_BRANCH=master
-JENKINS_GIT_REPOSITORY=git@github.com:jenkinsci/jenkins.git
+RELEASE_GIT_BRANCH=master
+RELEASE_GIT_REPOSITORY=git@github.com:jenkinsci/jenkins.git
 JENKINS_VERSION=stable
 GIT_EMAIL=release@jenkins.io
 GIT_NAME=release-bot

--- a/profile.d/weekly
+++ b/profile.d/weekly
@@ -1,5 +1,5 @@
-JENKINS_GIT_BRANCH=master
-JENKINS_GIT_REPOSITORY=git@github.com:jenkinsci/jenkins.git
+RELEASE_GIT_BRANCH=master
+RELEASE_GIT_REPOSITORY=git@github.com:jenkinsci/jenkins.git
 JENKINS_VERSION=weekly
 GIT_EMAIL=release@jenkins.io
 GIT_NAME=release-bot

--- a/utils/release.sh
+++ b/utils/release.sh
@@ -337,7 +337,7 @@ function rollback(){
 function stageRelease(){
   requireGPGPassphrase
   requireKeystorePass
-  printf "\\n Perform Jenkins Release\\n\\n"
+  printf "\\n Stage Jenkins Release\\n\\n"
   # Do not display transfer progress when downloading or uploading
   # https://maven.apache.org/ref/3.6.1/maven-embedder/cli.html
   mvn -B \
@@ -346,6 +346,19 @@ function stageRelease(){
     --no-transfer-progress \
     -Darguments=--no-transfer-progress \
     release:stage
+}
+
+function performRelease(){
+  requireGPGPassphrase
+  requireKeystorePass
+  printf "\\n Perform Jenkins Release\\n\\n"
+  # Do not display transfer progress when downloading or uploading
+  # https://maven.apache.org/ref/3.6.1/maven-embedder/cli.html
+  mvn -B \
+    -s settings-release.xml \
+    --no-transfer-progress \
+    -Darguments=--no-transfer-progress \
+    release:perform
 }
 
 function validateKeystore(){
@@ -395,10 +408,11 @@ function main(){
             --validateKeystore) echo "Validate Keystore"  && validateKeystore ;;
             --verifyGPGSignature) echo "Verify GPG Signature" && verifyGPGSignature ;;
             --verifyCertificateSignature) echo "Verify certificate signature" && verifyCertificateSignature ;;
+            --performRelease) echo "Perform Release" && performRelease ;;
             --prepareRelease) echo "Prepare Release" && generateSettingsXml && prepareRelease ;;
             --pushCommits) echo "Push commits on $RELEASE_GIT_BRANCH" && pushCommits ;;
             --rollback) echo "Rollback release $RELEASE_SCM_TAG" && rollblack ;;
-            --stageRelease) echo "Perform Release" && stageRelease ;;
+            --stageRelease) echo "Stage Release" && stageRelease ;;
             --packaging) echo 'Execute packaging makefile, quote required around Makefile target' && packaging "$2";;
             --syncMirror) echo 'Trigger mirror synchronization' && syncMirror ;;
             -h) echo "help" ;;

--- a/utils/release.sh
+++ b/utils/release.sh
@@ -11,7 +11,7 @@ source ""$(dirname "$(dirname "$0")")"/profile.d/$RELEASE_PROFILE"
 
 : "${WORKSPACE:=$PWD}" # Normally defined from Jenkins environment
 
-: "${JENKINS_GIT_BRANCH:=experimental}"
+: "${RELEASE_GIT_BRANCH:=experimental}"
 : "${WORKING_DIRECTORY:=release}"
 : "${GIT_EMAIL:=jenkins-bot@example.com}"
 : "${GIT_NAME:=jenkins-bot}"
@@ -84,11 +84,11 @@ function cloneJenkinsGitRepository(){
   # `ssh` is needed as git clone doesn't use GIT_SSH_COMMAND
   # https://git-scm.com/docs/git#Documentation/git.txt-codeGITSSHCOMMANDcode
   ssh -o StrictHostKeyChecking=no -T git@github.com || true
-  git clone --branch "${JENKINS_GIT_BRANCH}" "${JENKINS_GIT_REPOSITORY}" .
+  git clone --branch "${RELEASE_GIT_BRANCH}" "${RELEASE_GIT_REPOSITORY}" .
 }
 
 function configureGit(){
-  git checkout "${JENKINS_GIT_BRANCH}"
+  git checkout "${RELEASE_GIT_BRANCH}"
   git config --local user.email "${GIT_EMAIL}"
   git config --local user.name "${GIT_NAME}"
 }
@@ -326,7 +326,7 @@ function pushCommits(){
   git config --get remote.origin.url
   sed -i 's#url = https://github.com/#url = git@github.com:#' .git/config
   git pull 
-  git push origin "HEAD:$JENKINS_GIT_BRANCH" "$RELEASE_SCM_TAG"
+  git push origin "HEAD:$RELEASE_GIT_BRANCH" "$RELEASE_SCM_TAG"
 }
 
 function rollback(){
@@ -396,7 +396,7 @@ function main(){
             --verifyGPGSignature) echo "Verify GPG Signature" && verifyGPGSignature ;;
             --verifyCertificateSignature) echo "Verify certificate signature" && verifyCertificateSignature ;;
             --prepareRelease) echo "Prepare Release" && generateSettingsXml && prepareRelease ;;
-            --pushCommits) echo "Push commits on $JENKINS_GIT_BRANCH" && pushCommits ;;
+            --pushCommits) echo "Push commits on $RELEASE_GIT_BRANCH" && pushCommits ;;
             --rollback) echo "Rollback release $RELEASE_SCM_TAG" && rollblack ;;
             --stageRelease) echo "Perform Release" && stageRelease ;;
             --packaging) echo 'Execute packaging makefile, quote required around Makefile target' && packaging "$2";;

--- a/utils/release.sh
+++ b/utils/release.sh
@@ -80,7 +80,7 @@ function clean(){
     mvn -s settings-release.xml -B --no-transfer-progress -Darguments=--no-transfer-progress release:clean
 }
 
-function cloneJenkinsGitRepository(){
+function cloneReleaseGitRepository(){
   # `ssh` is needed as git clone doesn't use GIT_SSH_COMMAND
   # https://git-scm.com/docs/git#Documentation/git.txt-codeGITSSHCOMMANDcode
   ssh -o StrictHostKeyChecking=no -T git@github.com || true
@@ -384,7 +384,7 @@ function main(){
     do
       case "$1" in
             --cleanRelease) echo "Clean Release" && generateSettingsXml && clean;;
-            --cloneJenkinsGitRepository) echo "Cloning Jenkins Repository" && cloneJenkinsGitRepository ;;
+            --cloneReleaseGitRepository) echo "Cloning Jenkins Repository" && cloneReleaseGitRepository ;;
             --configureGPG) echo "ConfigureGPG" && configureGPG ;;
             --configureKeystore) echo "Configure Keystore" && configureKeystore ;;
             --configureGit) echo "Configure Git" && configureGit ;;


### PR DESCRIPTION
This pull request makes it a little bit more generic in order to use scripts in this repository for releasing jenkins components as well.
I was able to test locally all the parts including publishing artifacts on repo.jenkins-ci.org in a private repository.

The only part that I wasn't able to easily reuse are `utils/release.sh --verifyGPGSignature` and `utils/release.sh --verifyCertificateSignature` as we need to know in advance artifact name and at the moment they contain version numbers like `remoting-4.4.jar` vs `remoting.jar` 

In order for this pull request to, we also have to configure maven release plugin on jenkinsci/remoting  as proposed in this [PR](https://github.com/jenkinsci/remoting/pull/381) and obviously also configure release.ci.jenkins.io  

https://issues.jenkins-ci.org/browse/INFRA-2619