### PR TITLE
Add networkpolicy label to windows template

### DIFF
--- a/PodTemplates.d/package-windows
+++ b/PodTemplates.d/package-windows
@@ -4,6 +4,8 @@ metadata:
   labels:
     jenkins: "slave"
     job: "package"
+    #Following label is required by the NetworkPolicy managed by stable/jenkins helm chart and configured from jenkins-infra/charts
+    jenkins/default-release-jenkins-jenkins-slave: true
 spec:
   containers:
   - args:

--- a/PodTemplates.d/package-windows
+++ b/PodTemplates.d/package-windows
@@ -5,7 +5,7 @@ metadata:
     jenkins: "slave"
     job: "package"
     #Following label is required by the NetworkPolicy managed by stable/jenkins helm chart and configured from jenkins-infra/charts
-    jenkins/default-release-jenkins-jenkins-slave: true
+    jenkins/default-release-jenkins-agent: true
 spec:
   containers:
   - args:


### PR DESCRIPTION
This label is needed by the jenkins master from release environment [link](https://github.com/jenkins-infra/charts/tree/master/helmfile.d/jenkins-release)

It needs to be jenkins/<helm-release-name>-<agentComponentName>: true

Because this image is packaged with jnlp for windows we don't try to inherit podtemplate settings from jenkins master like we do for linux PodTemplates, maybe we could have a similar approach where our PodTemplate is composed of two containers [jnlp,vstools] @slide? in which case we don't have to specify this label here but instead we just use something similar to [this](https://github.com/jenkins-infra/release/blob/master/Jenkinsfile.d/core/package#L6)