### PR TITLE
Update dotnet container used for windows packaging

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -247,24 +247,26 @@ pipeline {
                 }
               }
               steps {
-                checkout scm
-                dir (WORKING_DIRECTORY){
-                  git branch: PACKAGING_GIT_BRANCH, credentialsId: 'release-key', url: PACKAGING_GIT_REPOSITORY
+                container('dotnet') {
+                  checkout scm
+                  dir (WORKING_DIRECTORY){
+                    git branch: PACKAGING_GIT_BRANCH, credentialsId: 'release-key', url: PACKAGING_GIT_REPOSITORY
 
-                  unstash 'GPG'
-                  unstash 'WAR'
-                  unstash 'KEYSTORE'
+                    unstash 'GPG'
+                    unstash 'WAR'
+                    unstash 'KEYSTORE'
 
-                  powershell '''
-                    Get-ChildItem env:
-                    $env:WAR=(Resolve-Path .\\jenkins.war).Path
-                    & .\\make.ps1
-                  '''
-                  // Don't archive the full path
-                  dir('msi\\build\\bin\\Release\\en-US') {
-                    archiveArtifacts '*.msi*'
+                    powershell '''
+                      Get-ChildItem env:
+                      $env:WAR=(Resolve-Path .\\jenkins.war).Path
+                      & .\\make.ps1
+                    '''
+                    // Don't archive the full path
+                    dir('msi\\build\\bin\\Release\\en-US') {
+                      archiveArtifacts '*.msi*'
+                    }
+
                   }
-
                 }
               }
             }

--- a/PodTemplates.d/package-windows
+++ b/PodTemplates.d/package-windows
@@ -19,21 +19,29 @@ spec:
     - "${nodeName}"
     command:
     - "powershell.exe"
-    image: "jenkins4eval/jnlp-agent-vstools-managed"
+    image: "jenkins/inbound-agent:windowsservercore-1809"
     imagePullPolicy: "Always"
     name: "jnlp"
     resources:
       limits:
-        memory: "8Gi"
-        cpu: "2"
+        memory: "4Gi"
+        cpu: "1"
       requests:
-        memory: "8Gi"
-        cpu: "2"
+        memory: "4Gi"
+        cpu: "1"
+  - args:
+    image: "mcr.microsoft.com/dotnet/framework/sdk:3.5"
+    imagePullPolicy: "Always"
+    name: "dotnet"
+    resources:
+      limits:
+        memory: "4Gi"
+        cpu: "1"
+      requests:
+        memory: "4Gi"
+        cpu: "1"
     securityContext:
       privileged: false
-      # Error: run as uid (1000) is not supported on Windows
-      # runAsUser: 1000
-      # runAsGroup: 1000
     tty: false
     volumeMounts:
       - name: core-packages


### PR DESCRIPTION
I never tested if windows agent now works with different containers, one for jnlp connection and another for dotnet