### PR TITLE
Weekly "release" must release the latest version available

### DIFF
--- a/utils/getJenkinsVersion.py
+++ b/utils/getJenkinsVersion.py
@@ -52,7 +52,7 @@ def getJenkinsVersion(metadataUrl, version):
         # Search in Maven repository for latest version of Jenkins
         # that satisfies X.Y which represents weekly version
         elif version == 'weekly':
-            result = root.find('versioning/release').text
+            result = root.find('versioning/latest').text
 
         # In this case we assume that we provided a valid version
         elif len(version.split('.')) > 0:


### PR DESCRIPTION
.metadata.xml
```
<metadata>
<groupId>org.jenkins-ci.main</groupId>
<artifactId>jenkins-war</artifactId>
<versioning>
    <latest>2.241</latest>
    <release>2.235.1</release>
...
```

versioning/release contains the latest release version in date and not in terms of the version number