### PR TITLE
Override default dotnet process

### DIFF
--- a/PodTemplates.d/package-windows
+++ b/PodTemplates.d/package-windows
@@ -30,6 +30,10 @@ spec:
         memory: "4Gi"
         cpu: "1"
   - args:
+      - -Command
+      - Start-Sleep -s 7776000 # We must be sure that the process used by the container doesn't stop before the Jenkins job
+    command:
+      - "powershell.exe"
     image: "mcr.microsoft.com/dotnet/framework/sdk:3.5"
     imagePullPolicy: "Always"
     name: "dotnet"


### PR DESCRIPTION
Signed-off-by: Olivier Vernin <olivier@vernin.me>

Tested with the command 
```
 kubectl run --generator=run-pod/v1  -n release --image=mcr.microsoft.com/dotnet/framework/sdk:3.5 --overrides='{"apiVersion":"v1","spec":{"affinity":{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchFields":[{"key":"metadata.name","operator":"In","values":["akswin000002"]}]}]}}},"tolerations": [{"key": "os","operator":"Equal","value": "windows","effect": "NoSchedule"}]}}
' dotnet -- powershell.exe -Command 'Start-Sleep -s 3600'
```
and the  container is correctly sleeping