### PR TITLE
Reduce sleeping second for dotnet container

### DIFF
--- a/PodTemplates.d/package-windows
+++ b/PodTemplates.d/package-windows
@@ -31,7 +31,7 @@ spec:
         cpu: "1"
   - args:
       - -Command
-      - Start-Sleep -s 7776000 # We must be sure that the process used by the container doesn't stop before the Jenkins job
+      - Start-Sleep -s 2147483 # We must be sure that the process used by the container doesn't stop before the Jenkins job and second isn not greater than 2147483
     command:
       - "powershell.exe"
     image: "mcr.microsoft.com/dotnet/framework/sdk:3.5"

--- a/PodTemplates.d/package-windows
+++ b/PodTemplates.d/package-windows
@@ -31,7 +31,7 @@ spec:
         cpu: "1"
   - args:
       - -Command
-      - Start-Sleep -s 2147483 # We must be sure that the process used by the container doesn't stop before the Jenkins job and second isn not greater than 2147483
+      - Start-Sleep -s 2147483 # We must be sure that the process used by the container doesn't stop before the Jenkins job and second is not greater than 2147483
     command:
       - "powershell.exe"
     image: "mcr.microsoft.com/dotnet/framework/sdk:3.5"


### PR DESCRIPTION
Signed-off-by: Olivier Vernin <olivier@vernin.me>

Message error
```
Start-Sleep : Cannot validate argument on parameter 'Seconds'. The 7776000 
argument is greater than the maximum allowed range of 2147483. Supply an 
argument that is less than or equal to 2147483 and then try the command again.
At line:1 char:16
+ Start-Sleep -s 7776000
+                ~~~~~~~
    + CategoryInfo          : InvalidData: (:) [Start-Sleep], ParameterBinding 
   ValidationException
    + FullyQualifiedErrorId : ParameterArgumentValidationError,Microsoft.Power 
   Shell.Commands.StartSleepCommand

```