### PR TITLE
Release plan

### DIFF
--- a/Jenkinsfile.d/components/remoting
+++ b/Jenkinsfile.d/components/remoting
@@ -50,6 +50,18 @@ pipeline {
           }
         }
       }
+      stage('Plan') {
+        steps {
+          container('maven') {
+            sh 'utils/release.sh --showReleasePlan'
+          }
+        }
+      }
+      stage('Validate') {
+        input {
+          message 'Are you ok to proceed?'
+        }
+      }
       stage('Get Code Signing Certificate') {
         steps {
           container('azure-cli') {

--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -52,6 +52,11 @@ pipeline {
       description: 'Enable Git repository promotion',
       name: 'GIT_STAGING_REPOSITORY_PROMOTION_ENABLED'
     )
+    booleanParam(
+      defaultValue: true,
+      description: 'Define if we wait for validation after displaying the plan or not',
+      name: 'VALIDATION_ENABLED'
+    )
   }
 
   options {
@@ -87,6 +92,23 @@ pipeline {
   }
 
   stages {
+    stage('Plan') {
+      steps {
+        container('packaging') {
+          sh 'utils/release.sh --showPackagingPlan'
+        }
+      }
+    }
+    stage('Validate') {
+      when {
+        environment name: 'VALIDATION_ENABLED', value: 'true'
+        beforeInput true
+      }
+
+      input {
+        message 'Are you ok to proceed?'
+      }
+    }
     stage('Get GPG key') {
 
       steps {

--- a/Jenkinsfile.d/core/release
+++ b/Jenkinsfile.d/core/release
@@ -37,6 +37,11 @@ pipeline {
       name: 'MAVEN_REPOSITORY_NAME',
       trim: false
     )
+    booleanParam(
+      defaultValue: true,
+      description: 'Define if we wait for validation after displaying the plan',
+      name: 'VALIDATION_ENABLED'
+    )
   }
 
   options {
@@ -72,6 +77,24 @@ pipeline {
           sh 'utils/release.sh --cleanRelease'
         }
       }
+    }
+    stage('Plan') {
+      steps {
+        container('maven') {
+          sh 'utils/release.sh --showReleasePlan'
+        }
+      }
+    }
+    stage('Validate') {
+      when {
+        environment name: 'VALIDATION_ENABLED', value: 'true'
+        beforeInput true
+      }
+
+      input {
+        message 'Are you ok to proceed?'
+      }
+
     }
     stage('Get Code Signing Certificate') {
       steps {

--- a/Jenkinsfile.d/core/weekly
+++ b/Jenkinsfile.d/core/weekly
@@ -19,6 +19,7 @@ pipeline {
     stage("Release"){
       steps {
         build job: 'core/release/master', parameters: [
+          booleanParam(name: "VALIDATION_ENABLED", value: false),
           string(name: "RELEASE_PROFILE", value: "weekly")
         ]
       }
@@ -27,6 +28,7 @@ pipeline {
     stage("Package"){
       steps {
         build job: 'core/package/master', parameters: [
+          booleanParam(name: "VALIDATION_ENABLED", value: false),
           string(name: "RELEASE_PROFILE", value: "weekly"),
           string(name: "JENKINS_VERSION", value: "weekly")
         ]

--- a/profile.d/security
+++ b/profile.d/security
@@ -28,6 +28,6 @@ RELEASE_GIT_PRODUCTION_BRANCH=master
 
 MAVEN_REPOSITORY_PRODUCTION_NAME=releases
 
-# Following line will move every items from source to destination, keep in mind that it deletes from source and override on destination if already exist!.
-# It's wise to disable delete permission on destination repository as explained here https://www.jfrog.com/confluence/display/JFROG/Permissions#Permissions-RepositoryPermissions
-PROMOTE_STAGING_MAVEN_ARTIFACTS_ARGS="item --mode move --source $MAVEN_REPOSITORY_NAME --destination $MAVEN_REPOSITORY_PRODUCTION_NAME --url $MAVEN_REPOSITORY_URL --username $MAVEN_REPOSITORY_USERNAME --password $MAVEN_REPOSITORY_PASSWORD --search '/org/jenkins-ci/main' $(../utils/getJenkinsVersion.py --version)"
+## Following line will move every items from source to destination, keep in mind that it deletes from source and override on destination if already exist!.
+## It's wise to disable delete permission on destination repository as explained here https://www.jfrog.com/confluence/display/JFROG/Permissions#Permissions-RepositoryPermissions
+#PROMOTE_STAGING_MAVEN_ARTIFACTS_ARGS="item --mode move --source $MAVEN_REPOSITORY_NAME --destination $MAVEN_REPOSITORY_PRODUCTION_NAME --url $MAVEN_REPOSITORY_URL --username $MAVEN_REPOSITORY_USERNAME --password $MAVEN_REPOSITORY_PASSWORD --search '/org/jenkins-ci/main' $(./utils/getJenkinsVersion.py --version)"

--- a/profile.d/security
+++ b/profile.d/security
@@ -12,7 +12,6 @@ GIT_NAME=release-bot
 GPG_KEYNAME=62A9756BFD780C377CF24BA8FCEF32E745F2C3D5
 GPG_VAULT_NAME=jenkins-release-pgp
 MAVEN_REPOSITORY_URL=https://repo.jenkins-ci.org
-# MAVEN_REPOSITORY_NAME is provided at run time
 MAVEN_PUBLIC_JENKINS_REPOSITORY_MIRROR_URL='http://nexus/repository/jenkins-public/'
 SIGN_ALIAS=jenkins
 
@@ -27,7 +26,3 @@ RELEASE_GIT_PRODUCTION_BRANCH=master
 #         as retrieved from ./utils/getJenkinsVersion.py
 
 MAVEN_REPOSITORY_PRODUCTION_NAME=releases
-
-## Following line will move every items from source to destination, keep in mind that it deletes from source and override on destination if already exist!.
-## It's wise to disable delete permission on destination repository as explained here https://www.jfrog.com/confluence/display/JFROG/Permissions#Permissions-RepositoryPermissions
-#PROMOTE_STAGING_MAVEN_ARTIFACTS_ARGS="item --mode move --source $MAVEN_REPOSITORY_NAME --destination $MAVEN_REPOSITORY_PRODUCTION_NAME --url $MAVEN_REPOSITORY_URL --username $MAVEN_REPOSITORY_USERNAME --password $MAVEN_REPOSITORY_PASSWORD --search '/org/jenkins-ci/main' $(./utils/getJenkinsVersion.py --version)"

--- a/utils/release.sh
+++ b/utils/release.sh
@@ -42,6 +42,11 @@ source ""$(dirname "$(dirname "$0")")"/profile.d/$RELEASE_PROFILE"
 : "${RELEASE_GIT_STAGING_BRANCH:=$RELEASE_GIT_BRANCH}"
 : "${RELEASE_GIT_PRODUCTION_REPOSITORY:=$RELEASE_GIT_REPOSITORY }"
 : "${RELEASE_GIT_PRODUCTION_BRANCH:=$RELEASE_GIT_BRANCH}"
+# Following line will copy every items from source to destination,
+# keeps in mind that it won't delete from source and override on destination if already exist!.
+# It's wise to disable delete permission on destination repository
+# as explained here https://www.jfrog.com/confluence/display/JFROG/Permissions#Permissions-RepositoryPermissions
+: "${PROMOTE_STAGING_MAVEN_ARTIFACTS_ARGS:=item --mode copy --source $MAVEN_REPOSITORY_NAME --destination $MAVEN_REPOSITORY_PRODUCTION_NAME --url $MAVEN_REPOSITORY_URL --username $MAVEN_REPOSITORY_USERNAME --password $MAVEN_REPOSITORY_PASSWORD --search '/org/jenkins-ci/main' $(./utils/getJenkinsVersion.py --version)}"
 
 export JENKINS_VERSION
 export JENKINS_DOWNLOAD_URL
@@ -432,9 +437,9 @@ EOF
 }
 
 function showPackagingPlan(){
-  "$WORKSPACE"/utils/plan.py --packaging
+
 cat <<-EOF
-    New Jenkins core packages will be generated for the $JENKINS_VERSION version 
+    New Jenkins core packages will be generated for version $(../utils/getJenkinsVersion.py --version)
 
     Those new packages will be generated based on a war file downloaded
     from $JENKINS_DOWNLOAD_URL
@@ -447,7 +452,7 @@ cat <<-EOF
     Git repository promotion is enabled
     Git commits will be promoted from:
         $RELEASE_GIT_STAGING_REPOSITORY:$RELEASE_GIT_STAGING_BRANCH to
-        $RELEASE_GIT_PRODUCTION_REPOSITORY:$RELEASE_GIT_PRODUCTION_BRANCH to
+        $RELEASE_GIT_PRODUCTION_REPOSITORY:$RELEASE_GIT_PRODUCTION_BRANCH
 EOF
   else
     echo Git Repository promotion is disabled

--- a/utils/release.sh
+++ b/utils/release.sh
@@ -36,6 +36,13 @@ source ""$(dirname "$(dirname "$0")")"/profile.d/$RELEASE_PROFILE"
 
 : "${JENKINS_DOWNLOAD_URL:=$MAVEN_REPOSITORY_URL/$MAVEN_REPOSITORY_NAME/org/jenkins-ci/main/jenkins-war/}"
 
+# Promotion Settings
+: "${RELEASE_GIT_STAGING_REPOSITORY_PATH:=$WORKSPACE/stagingGitRepository}"
+: "${RELEASE_GIT_STAGING_REPOSITORY:=$RELEASE_GIT_REPOSITORY}"
+: "${RELEASE_GIT_STAGING_BRANCH:=$RELEASE_GIT_BRANCH}"
+: "${RELEASE_GIT_PRODUCTION_REPOSITORY:=$RELEASE_GIT_REPOSITORY }"
+: "${RELEASE_GIT_PRODUCTION_BRANCH:=$RELEASE_GIT_BRANCH}"
+
 export JENKINS_VERSION
 export JENKINS_DOWNLOAD_URL
 export MAVEN_REPOSITORY_USERNAME
@@ -331,14 +338,6 @@ function promoteStagingMavenArtifacts(){
 
 function promoteStagingGitRepository(){
 
-  : "${RELEASE_GIT_STAGING_REPOSITORY_PATH:=$WORKSPACE/stagingGitRepository}"
-
-  : "${RELEASE_GIT_STAGING_REPOSITORY:=$RELEASE_GIT_REPOSITORY}"
-  : "${RELEASE_GIT_STAGING_BRANCH:=$RELEASE_GIT_BRANCH}"
-
-  : "${RELEASE_GIT_PRODUCTION_REPOSITORY:?Required remote origin like git@github.com:jenkinsci/jenkins.git }"
-  : "${RELEASE_GIT_PRODUCTION_BRANCH:=$RELEASE_GIT_BRANCH}"
-
   # Ensure we always work from a clean environment
   if [ -d "$RELEASE_GIT_STAGING_REPOSITORY_PATH" ];then
     rm -Rf "$RELEASE_GIT_STAGING_REPOSITORY_PATH"
@@ -418,6 +417,55 @@ function verifyCertificateSignature(){
   jarsigner -verbose -verify -certs -strict "$JENKINS_WAR"
 }
 
+function showReleasePlan(){
+
+cat <<-EOF
+    A new $RELEASE_PROFILE release will be generated.
+
+    This new release will use the git repository: $RELEASE_GIT_REPOSITORY,
+    using branch $RELEASE_GIT_BRANCH then push commits to the same location.
+
+    Artifacts will be pushed to the maven repository named "$MAVEN_REPOSITORY_NAME"
+    located on "$MAVEN_REPOSITORY_URL" authenticated as "$MAVEN_REPOSITORY_USERNAME"
+EOF
+
+}
+
+function showPackagingPlan(){
+  "$WORKSPACE"/utils/plan.py --packaging
+cat <<-EOF
+    New Jenkins core packages will be generated for the $JENKINS_VERSION version 
+
+    Those new packages will be generated based on a war file downloaded
+    from $JENKINS_DOWNLOAD_URL
+
+    Once built, packages will be pushed to $PKGSERVER
+EOF
+
+  if $GIT_STAGING_REPOSITORY_PROMOTION_ENABLED -eq "true"; then
+cat <<-EOF
+    Git repository promotion is enabled
+    Git commits will be promoted from:
+        $RELEASE_GIT_STAGING_REPOSITORY:$RELEASE_GIT_STAGING_BRANCH to
+        $RELEASE_GIT_PRODUCTION_REPOSITORY:$RELEASE_GIT_PRODUCTION_BRANCH to
+EOF
+  else
+    echo Git Repository promotion is disabled
+  fi
+
+  if $MAVEN_STAGING_REPOSITORY_PROMOTION_ENABLED -eq "true"; then
+
+cat <<-EOF
+    Maven artifacts promotion is enabled
+    Artifacts will be promoted from repository $MAVEN_REPOSITORY_NAME to $MAVEN_REPOSITORY_PRODUCTION_NAME
+    located on artifactory at $MAVEN_REPOSITORY_URL
+EOF
+
+  else
+    echo "Maven repository promotion is disabled"
+  fi
+}
+
 function syncMirror(){
 
   PKGSERVER_SSH_OPTS=($PKGSERVER_SSH_OPTS)
@@ -454,6 +502,8 @@ function main(){
             --performRelease) echo "Perform Release" && performRelease ;;
             --prepareRelease) echo "Prepare Release" && generateSettingsXml && prepareRelease ;;
             --pushCommits) echo "Push commits on $RELEASE_GIT_BRANCH" && pushCommits ;;
+            --showReleasePlan) echo "Show Release Plan" && showReleasePlan ;;
+            --showPackagingPlan) echo "Show Packaging Plan" && showPackagingPlan ;;
             --promoteStagingMavenArtifacts) echo "Promote Staging Maven Artifacts" && promoteStagingMavenArtifacts ;;
             --promoteStagingGitRepository) echo "Promote Staging Git Repository" && promoteStagingGitRepository ;;
             --rollback) echo "Rollback release $RELEASE_SCM_TAG" && rollblack ;;


### PR DESCRIPTION
I propose to display based on parameters what we are going to do for releases and packaging jobs.
And by default we wait for user input to validate if we proceed or not, excepted for weekly releases where we don't wait for validation.

While initially I was thinking to do nice formatting using python + jinja2, I decided to not doing it so we don't introduce a new dependency on a python environment for the release part.  

Release plan looks like
```
+ echo 'Show Release Plan'
Show Release Plan
+ showReleasePlan
+ cat
    A new security release will be generated.

    This new release will use the git repository: git@github.com:jenkinsci-cert/jenkins.git,
    using branch experimental then push commits to the same location.

    Artifacts will be pushed to the maven repository named "releases"
    located on "https://repo.jenkins-ci.org" authenticated as "olblak"
+ shift

```

Packaging plan looks like
```
+ echo 'Show Packaging Plan'
Show Packaging Plan
+ showPackagingPlan
+ cat
++ ../utils/getJenkinsVersion.py --version
    New Jenkins core packages will be generated for version 2.241

    Those new packages will be generated based on a war file downloaded
    from https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/

    Once built, packages will be pushed to mirrorbrain@pkg.origin.jenkins.io
+ true -eq true
+ cat
    Git repository promotion is enabled
    Git commits will be promoted from:
        git@github.com:jenkinsci-cert/jenkins.git:experimental to
        git@github.com:jenkinsci/jenkins.git:master
+ true -eq true
+ cat
    Maven artifacts promotion is enabled
    Artifacts will be promoted from repository releases to releases
    located on artifactory at https://repo.jenkins-ci.org
+ shift
+ '[' 0 -gt 0 ']'
```