### PR TITLE
[INFRA-2660] core release profile trigger build job based on current branch

### DIFF
--- a/Jenkinsfile.d/core/security
+++ b/Jenkinsfile.d/core/security
@@ -34,7 +34,7 @@ pipeline {
   stages {
     stage("Release"){
       steps {
-        build job: 'core/release/master', parameters: [
+        build job: "core/release/${ BRANCH_NAME }", parameters: [
           string(name: "RELEASE_PROFILE", value: "security"),
           string(name: "RELEASE_GIT_BRANCH", value: params.RELEASE_GIT_BRANCH),
           string(name: "MAVEN_REPOSITORY_NAME", value: params.MAVEN_REPOSITORY_NAME)
@@ -43,7 +43,7 @@ pipeline {
     }
     stage("Package"){
       steps {
-        build job: 'core/package/master', parameters: [
+        build job: "core/package/${ BRANCH_NAME }", parameters: [
           string(name: "RELEASE_PROFILE", value: "security"),
           string(name: "JENKINS_VERSION", value: params.JENKINS_VERSION),
           string(name: "RELEASE_GIT_BRANCH", value: params.RELEASE_GIT_BRANCH),

--- a/Jenkinsfile.d/core/stable
+++ b/Jenkinsfile.d/core/stable
@@ -13,14 +13,14 @@ pipeline {
   stages {
     stage("Release"){
       steps {
-        build job: 'core/release/master', parameters: [
+        build job: "core/release/${ BRANCH_NAME }", parameters: [
           string(name: "RELEASE_PROFILE", value: "stable")
         ]
       }
     }
     stage("Package"){
       steps {
-        build job: 'core/package/master', parameters: [
+        build job: "core/package/${ BRANCH_NAME }", parameters: [
           string(name: "RELEASE_PROFILE", value: "stable"),
           string(name: "JENKINS_VERSION", value: "stable")
         ]

--- a/Jenkinsfile.d/core/weekly
+++ b/Jenkinsfile.d/core/weekly
@@ -18,7 +18,7 @@ pipeline {
   stages {
     stage("Release"){
       steps {
-        build job: 'core/release/master', parameters: [
+        build job: "core/release/${ BRANCH_NAME }", parameters: [
           booleanParam(name: "VALIDATION_ENABLED", value: false),
           string(name: "RELEASE_PROFILE", value: "weekly")
         ]
@@ -27,7 +27,7 @@ pipeline {
 
     stage("Package"){
       steps {
-        build job: 'core/package/master', parameters: [
+        build job: "core/package/${ BRANCH_NAME }", parameters: [
           booleanParam(name: "VALIDATION_ENABLED", value: false),
           string(name: "RELEASE_PROFILE", value: "weekly"),
           string(name: "JENKINS_VERSION", value: "weekly")


### PR DESCRIPTION
[INFRA-2660](https://issues.jenkins-ci.org/browse/INFRA-2660)
Release build job now trigger jobs based on current branch, this PR works with this [one](https://github.com/jenkins-infra/charts/pull/265).

It allows us to trigger releases using a different branch than the master one