### PR TITLE
Add maven.jenkins-ci.org server id

### DIFF
--- a/utils/release.sh
+++ b/utils/release.sh
@@ -280,6 +280,12 @@ cat <<EOT> settings-release.xml
       <username>$MAVEN_REPOSITORY_USERNAME</username>
       <password>$MAVEN_REPOSITORY_PASSWORD</password>
     </server>
+    <!--This server id is used by jenkinsci/remoting -->
+    <server>
+      <id>maven.jenkins-ci.org</id>
+      <username>$MAVEN_REPOSITORY_USERNAME</username>
+      <password>$MAVEN_REPOSITORY_PASSWORD</password>
+    </server>
   </servers>
   <activeProfiles>
     <activeProfile>release</activeProfile>


### PR DESCRIPTION
[jenkinsci/remoting](https://github.com/jenkinsci/remoting) is using this server id to push artifacts, while this url appears to be legacy, I don't really have the time to propose a better solution for now.

PS: This is how I finished the last remoting release [here](https://release.ci.jenkins.io/job/components/job/remoting/job/master/18/console)