### PR TITLE
Try old version of maven to fix signing issue

### DIFF
--- a/PodTemplates.d/release-linux.yaml
+++ b/PodTemplates.d/release-linux.yaml
@@ -33,7 +33,7 @@ spec:
       value: "/home/jenkins/agent/workspace"
     - name: "MAVEN_OPTS"
       value: "-Xmx8g -Xms8g"
-    image: "maven:3-jdk-8"
+    image: "maven:3.6.2-jdk-8"
     imagePullPolicy: "Always"
     name: "maven"
     resources:


### PR DESCRIPTION
Releasing failed on 'JDK Version: 1.8.0_262'

This image has:
```
Apache Maven 3.6.2 (40f52333136460af0dc0d7232c0dc0bcf0d9e117; 2019-08-27T15:06:16Z)
Maven home: /usr/share/maven
Java version: 1.8.0_232, vendor: Oracle Corporation, runtime: /usr/local/openjdk-8/jre
Default locale: en, platform encoding: UTF-8
OS name: "linux", version: "4.19.76-linuxkit", arch: "amd64", family: "unix"
```
