### PR TITLE
Add windows packaging enabled flag for core packaging

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -57,6 +57,11 @@ pipeline {
       description: 'Define if we wait for validation after displaying the plan or not',
       name: 'VALIDATION_ENABLED'
     )
+    booleanParam(
+      defaultValue: false,
+      description: 'Enable Windows Packaging',
+      name: 'WINDOWS_PACKAGING_ENABLED'
+    )
   }
 
   options {
@@ -267,6 +272,9 @@ pipeline {
           }
         }
         stage('Windows') {
+          when {
+            environment name: 'WINDOWS_PACKAGING_ENABLED', value: 'true'
+          }
           stages {
             stage('Build') {
               // Windows requirement: Every steps need to be executed inside default jnlp


### PR DESCRIPTION
We recently had multiple issues with the windows packaging that impacted the release process so I propose to have a flag to easily disable it, and by default it is set to false so we can still retrigger a packaging build afterward