### PR TITLE
Update stable release profile for stable-2.235

### DIFF
--- a/profile.d/stable
+++ b/profile.d/stable
@@ -2,16 +2,18 @@
 # WARNING: Any variables defined here, override those defined from the Jenkinsfile
 #
 #
-RELEASE_GIT_BRANCH=master
 RELEASE_GIT_REPOSITORY=git@github.com:jenkinsci/jenkins.git
 GIT_EMAIL=66998184+jenkins-release-bot@users.noreply.github.com
 GIT_NAME="Jenkins Release Bot"
 GPG_KEYNAME="62A9756BFD780C377CF24BA8FCEF32E745F2C3D5"
 GPG_VAULT_NAME="jenkins-release-pgp"
 MAVEN_REPOSITORY_URL='https://repo.jenkins-ci.org'
-MAVEN_REPOSITORY_NAME=releases-stable
 MAVEN_PUBLIC_JENKINS_REPOSITORY_MIRROR_URL='http://nexus/repository/jenkins-public/'
 SIGN_ALIAS=jenkins
 
 # Used by jenkinsci/packaging
 RELEASELINE=-stable
+
+# Custom Parameters
+RELEASE_GIT_BRANCH=stable-2.235
+MAVEN_REPOSITORY_NAME=releases

--- a/profile.d/stable
+++ b/profile.d/stable
@@ -17,3 +17,4 @@ RELEASELINE=-stable
 # Custom Parameters
 RELEASE_GIT_BRANCH=stable-2.235
 MAVEN_REPOSITORY_NAME=releases
+JENKINS_VERSION=2.235.3 # Only create packages for version 2.235.3


### PR DESCRIPTION
Prepare stable release profile for release 2.235

Reminder:
* No promotion will be enabled
* Windows packaging will be disabled

Related to [PR#3563](https://github.com/jenkins-infra/jenkins.io/pull/3563)


Signed-off-by: Olivier Vernin <olivier@vernin.me>