### PR TITLE
By default build windows package

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -58,7 +58,7 @@ pipeline {
       name: 'VALIDATION_ENABLED'
     )
     booleanParam(
-      defaultValue: false,
+      defaultValue: true,
       description: 'Enable Windows Packaging',
       name: 'WINDOWS_PACKAGING_ENABLED'
     )


### PR DESCRIPTION
Now that this [PR](https://github.com/jenkinsci/docker-inbound-agent/pull/186) has been merged and a new inbound agent published, building MSI packages works again so it doesn't make sense to disable MSI packaging by default

Signed-off-by: Olivier Vernin <olivier@vernin.me>