### PR TITLE
Skip all stages on first build (before we know parameters)

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -98,6 +98,13 @@ pipeline {
 
   stages {
     stage('Plan') {
+      when {
+        not {
+          environment name: 'BUILD_NUMBER', value: '1'
+        }
+        beforeAgent true
+      }
+
       steps {
         container('packaging') {
           sh 'utils/release.sh --showPackagingPlan'
@@ -107,6 +114,9 @@ pipeline {
     stage('Validate') {
       when {
         environment name: 'VALIDATION_ENABLED', value: 'true'
+        not {
+          environment name: 'BUILD_NUMBER', value: '1'
+        }
         beforeInput true
       }
 
@@ -122,6 +132,12 @@ pipeline {
 
     }
     stage('Get GPG key') {
+      when {
+        not {
+          environment name: 'BUILD_NUMBER', value: '1'
+        }
+        beforeAgent true
+      }
 
       steps {
         container('azure-cli') {
@@ -146,6 +162,12 @@ pipeline {
     }
 
     stage('Get Code Signing Certificate') {
+      when {
+        not {
+          environment name: 'BUILD_NUMBER', value: '1'
+        }
+        beforeAgent true
+      }
 
       steps {
         container('azure-cli') {
@@ -160,6 +182,13 @@ pipeline {
     }
 
     stage('Download WAR archive to package'){
+      when {
+        not {
+          environment name: 'BUILD_NUMBER', value: '1'
+        }
+        beforeAgent true
+      }
+
       steps{
         container('packaging'){
           sh '''
@@ -173,6 +202,13 @@ pipeline {
       }
     }
     stage('Package'){
+      when {
+        not {
+          environment name: 'BUILD_NUMBER', value: '1'
+        }
+        beforeAgent true
+      }
+
       failFast false
       parallel {
         stage('WAR') {
@@ -326,6 +362,12 @@ pipeline {
       }
     }
     stage('Promote'){
+      when {
+        not {
+          environment name: 'BUILD_NUMBER', value: '1'
+        }
+        beforeAgent true
+      }
       failFast true
       parallel {
         stage('Maven Repository') {
@@ -361,6 +403,12 @@ pipeline {
     }
     // Force mirror synchronization
     stage('Synchronize mirror'){
+      when {
+        not {
+          environment name: 'BUILD_NUMBER', value: '1'
+        }
+        beforeAgent true
+      }
       steps{
         container('packaging'){
           sshagent(['pkgserver']) {
@@ -372,6 +420,12 @@ pipeline {
       }
     }
     stage('Invalidate Fastly Cache'){
+      when {
+        not {
+          environment name: 'BUILD_NUMBER', value: '1'
+        }
+        beforeAgent true
+      }
       environment {
         FASTLY_API_TOKEN = credentials('fastly-api-token')
         FASTLY_SERVICE_ID = credentials('fastly_pkgserver_service_id')

--- a/Jenkinsfile.d/core/release
+++ b/Jenkinsfile.d/core/release
@@ -63,6 +63,13 @@ pipeline {
 
   stages {
     stage('Clone Release Git Repository') {
+      when {
+        not {
+          environment name: 'BUILD_NUMBER', value: '1'
+        }
+        beforeAgent true
+      }
+
       steps {
         container('jnlp') {
           sshagent(['release-key']) {
@@ -72,6 +79,13 @@ pipeline {
       }
     }
     stage('Clean Release') {
+      when {
+        not {
+          environment name: 'BUILD_NUMBER', value: '1'
+        }
+        beforeAgent true
+      }
+
       steps {
         container('maven') {
           sh 'utils/release.sh --cleanRelease'
@@ -79,6 +93,13 @@ pipeline {
       }
     }
     stage('Plan') {
+      when {
+        not {
+          environment name: 'BUILD_NUMBER', value: '1'
+        }
+        beforeAgent true
+      }
+
       steps {
         container('maven') {
           sh 'utils/release.sh --showReleasePlan'
@@ -86,6 +107,13 @@ pipeline {
       }
     }
     stage('Validate') {
+      when {
+        not {
+          environment name: 'BUILD_NUMBER', value: '1'
+        }
+        beforeAgent true
+      }
+
       when {
         environment name: 'VALIDATION_ENABLED', value: 'true'
         beforeInput true
@@ -102,6 +130,13 @@ pipeline {
       }
     }
     stage('Get Code Signing Certificate') {
+      when {
+        not {
+          environment name: 'BUILD_NUMBER', value: '1'
+        }
+        beforeAgent true
+      }
+
       steps {
         container('azure-cli') {
           sh '''
@@ -112,6 +147,13 @@ pipeline {
       }
     }
     stage('Get GPG key') {
+      when {
+        not {
+          environment name: 'BUILD_NUMBER', value: '1'
+        }
+        beforeAgent true
+      }
+
       steps {
         container('azure-cli') {
           sh '''
@@ -121,6 +163,13 @@ pipeline {
       }
     }
     stage('Prepare Release') {
+      when {
+        not {
+          environment name: 'BUILD_NUMBER', value: '1'
+        }
+        beforeAgent true
+      }
+
       steps {
         container('maven') {
           // Maven Release requires gpg key with password password and a certificate key with password
@@ -138,6 +187,13 @@ pipeline {
       }
     }
     stage('Push Commits') {
+      when {
+        not {
+          environment name: 'BUILD_NUMBER', value: '1'
+        }
+        beforeAgent true
+      }
+
       // environment {
       //   GIT_SSH = 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $RELEASE_SSH_KEY'
       // }
@@ -162,6 +218,13 @@ pipeline {
       }
     }
     stage('Stage Release') {
+      when {
+        not {
+          environment name: 'BUILD_NUMBER', value: '1'
+        }
+        beforeAgent true
+      }
+
       steps {
         container('maven') {
           sh '''
@@ -171,6 +234,13 @@ pipeline {
       }
     }
     stage('Verify artifacts') {
+      when {
+        not {
+          environment name: 'BUILD_NUMBER', value: '1'
+        }
+        beforeAgent true
+      }
+
       steps {
         container('maven') {
           sh '''

--- a/README.adoc
+++ b/README.adoc
@@ -347,7 +347,7 @@ The security release follows the same process as the stable one except that arti
 .. `MAVEN_REPOSITORY_NAME` set to the maven repository name where we are going to publish staging maven artifacts. This is also the source location used by the packaging job to build distribution packages
 . Trigger the generic Release link:https://release.ci.jenkins.io/job/core/job/release/[job] from the appropriated branch like `security-stable-2.235`
 .. Force repository scan
-.. Trigger the first build to have access to job parameter and immediately abort it
+.. Trigger the first build to scan the script and wait until it finishes; it will skip all actual work.
 .. Trigger a job with the correct parameters
 ... `RELEASE_PROFILE` set to `security`
 ... `RELEASE_GIT_BRANCH` set to `unused` as we already define it in the release profile file, which overrides the job parameter


### PR DESCRIPTION
Side note: This looks pretty weird due to the very high number of very small stages. It is unclear to me why we're e.g. splitting GPG and code signing cert preparation into separate stages.