### PR TITLE
Display RELEASELINE in the pplan

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -345,6 +345,7 @@ The security release follows the same process as the stable one except that arti
 .. `JENKINS_VERSION` set to the final release version that will be packaged. If set to 'stable' or 'weekly' then the packaging job will try to guess the version based on what was pushed to the maven repository. cfr settings.
 .. `PACKAGING_GIT_BRANCH` set to the appropriated jenkinsci/packaging branch
 .. `MAVEN_REPOSITORY_NAME` set to the maven repository name where we are going to publish staging maven artifacts. This is also the source location used by the packaging job to build distribution packages
+.. `RELEASELINE` set to '-stable' for a lts release otherwise leave empty
 . Trigger the generic Release link:https://release.ci.jenkins.io/job/core/job/release/[job] from the appropriated branch like `security-stable-2.235`
 .. Force repository scan
 .. Trigger the first build to have access to job parameter and immediately abort it

--- a/utils/release.sh
+++ b/utils/release.sh
@@ -476,7 +476,7 @@ function verifyCertificateSignature(){
 function showReleasePlan(){
 
 cat <<-EOF
-    A new $RELEASE_PROFILE release will be generated.
+    A new $RELEASE_PROFILE release will be generated for the "${RELEASELINE:-weekly}" release).
 
     This new release will use the git repository: $RELEASE_GIT_REPOSITORY,
     using branch $RELEASE_GIT_BRANCH then push commits to the same location.
@@ -490,7 +490,7 @@ EOF
 function showPackagingPlan(){
 
 cat <<-EOF
-    New Jenkins core packages will be generated for version $(../utils/getJenkinsVersion.py --version)
+    New Jenkins core packages will be generated for version $(../utils/getJenkinsVersion.py --version) for the "${RELEASELINE:-weekly}" release
 
     Those new packages will be generated based on a war file downloaded
     from $JENKINS_DOWNLOAD_URL


### PR DESCRIPTION
Today during the lts security release,  we didn't detect that we didn't set RELEASELINE to '-stable'.
As a first iteration, I propose to add RELEASELINE to the plan and display 'weekly' if no RELEASELINE is provided as it is used for weekly releases
