### PR TITLE
Use specific version of the Windows container

### DIFF
--- a/PodTemplates.d/package-windows
+++ b/PodTemplates.d/package-windows
@@ -8,7 +8,7 @@ metadata:
     jenkins/default-release-jenkins-agent: true
 spec:
   containers:
-  - image: "jenkins/inbound-agent:windowsservercore-1809"
+  - image: "jenkins/inbound-agent:4.3-9-windowsservercore-1809"
     imagePullPolicy: "Always"
     name: "jnlp"
     resources:


### PR DESCRIPTION
We should use a specific version of the Windows container image. This is the version that has fixes for the password issue.