### PR TITLE
Disabling binary-core-packages volume for packaging

### DIFF
--- a/PodTemplates.d/package-linux
+++ b/PodTemplates.d/package-linux
@@ -27,8 +27,10 @@ spec:
       runAsGroup: 1000
     tty: true
     volumeMounts:
-      - name: binary-core-packages
-        mountPath: /srv/releases/jenkins
+# This file storage is currently broken, we have an open issue with Azure
+# so I am disabling it until find a solution
+#      - name: binary-core-packages
+#        mountPath: /srv/releases/jenkins
       - name: website-core-packages
         mountPath: /var/www/pkg.jenkins.io.staging/
   - command:
@@ -52,8 +54,10 @@ spec:
       runAsGroup: 1000
     tty: true
     volumeMounts:
-      - name: binary-core-packages
-        mountPath: /srv/releases/jenkins
+# This file storage is currently broken, we have an open issue with Azure
+# so I am disabling it until find a solution
+#      - name: binary-core-packages
+#        mountPath: /srv/releases/jenkins
       - name: website-core-packages
         mountPath: /var/www/pkg.jenkins.io.staging/
   affinity:
@@ -67,9 +71,11 @@ spec:
               - linux
   restartPolicy: "Never"
   volumes:
-    - name: binary-core-packages
-      persistentVolumeClaim:
-        claimName: binary-core-packages
+# This file storage is currently broken, we have an open issue with Azure
+# so I am disabling it until find a solution
+#    - name: binary-core-packages
+#      persistentVolumeClaim:
+#        claimName: binary-core-packages
     - name: website-core-packages
       persistentVolumeClaim:
         claimName: website-core-packages

--- a/PodTemplates.d/package-windows
+++ b/PodTemplates.d/package-windows
@@ -40,8 +40,10 @@ spec:
       - name: core-packages
         mountPath: 'C:/Packages'
     volumeMounts:
-      - name: binary-core-packages
-        mountPath: /Packages/binary
+# This file storage is currently broken, we have an open issue with Azure
+# so I am disabling it until find a solution
+#      - name: binary-core-packages
+#        mountPath: /Packages/binary
       - name: website-core-packages
         mountPath: /Packages/web
   affinity:
@@ -59,9 +61,11 @@ spec:
       value: "windows"
       effect: "NoSchedule"
   volumes:
-    - name: binary-core-packages
-      persistentVolumeClaim:
-        claimName: binary-core-packages
+# This file storage is currently broken, we have an open issue with Azure
+# so I am disabling it until find a solution
+#    - name: binary-core-packages
+#      persistentVolumeClaim:
+#        claimName: binary-core-packages
     - name: website-core-packages
       persistentVolumeClaim:
         claimName: website-core-packages


### PR DESCRIPTION
Release environment is pushing releases on the azure file storage used by get.jenkins.io. We know that this storage is not working correctly at the moment and the error we are facing from release.ci.jenkins.io is 

```
+ rsync --include HEADER.html --include FOOTER.html --exclude '*' --compress --recursive --progress --verbose /tmp/1274/html/ /srv/releases/jenkins/debian/
sending incremental file list
rsync: rename "/srv/releases/jenkins/debian/.HEADER.html.30lzaN" -> "HEADER.html": Permission denied (13)
```
For some reasons the file HEADER.html can't be open while FOOTER.html can, so we are totally disabling this volume until we figure it out.

Signed-off-by: Olivier Vernin <olivier@vernin.me>