### PR TITLE
Revert - disable file storage

### DIFF
--- a/PodTemplates.d/package-linux
+++ b/PodTemplates.d/package-linux
@@ -27,8 +27,10 @@ spec:
       runAsGroup: 1000
     tty: true
     volumeMounts:
-      - name: binary-core-packages
-        mountPath: /srv/releases/jenkins
+# This file storage is currently broken, we have an open issue with Azure
+# so I am disabling it until find a solution
+#      - name: binary-core-packages
+#        mountPath: /srv/releases/jenkins
       - name: website-core-packages
         mountPath: /var/www/pkg.jenkins.io.staging/
   - command:
@@ -52,8 +54,10 @@ spec:
       runAsGroup: 1000
     tty: true
     volumeMounts:
-      - name: binary-core-packages
-        mountPath: /srv/releases/jenkins
+# This file storage is currently broken, we have an open issue with Azure
+# so I am disabling it until find a solution
+#      - name: binary-core-packages
+#        mountPath: /srv/releases/jenkins
       - name: website-core-packages
         mountPath: /var/www/pkg.jenkins.io.staging/
   affinity:
@@ -72,8 +76,6 @@ spec:
 #    - name: binary-core-packages
 #      persistentVolumeClaim:
 #        claimName: binary-core-packages
-    - name: binary-core-packages
-      emptyDir: {}
     - name: website-core-packages
       persistentVolumeClaim:
         claimName: website-core-packages

--- a/PodTemplates.d/package-linux
+++ b/PodTemplates.d/package-linux
@@ -27,10 +27,8 @@ spec:
       runAsGroup: 1000
     tty: true
     volumeMounts:
-# This file storage is currently broken, we have an open issue with Azure
-# so I am disabling it until find a solution
-#      - name: binary-core-packages
-#        mountPath: /srv/releases/jenkins
+      - name: binary-core-packages
+        mountPath: /srv/releases/jenkins
       - name: website-core-packages
         mountPath: /var/www/pkg.jenkins.io.staging/
   - command:
@@ -54,10 +52,8 @@ spec:
       runAsGroup: 1000
     tty: true
     volumeMounts:
-# This file storage is currently broken, we have an open issue with Azure
-# so I am disabling it until find a solution
-#      - name: binary-core-packages
-#        mountPath: /srv/releases/jenkins
+      - name: binary-core-packages
+        mountPath: /srv/releases/jenkins
       - name: website-core-packages
         mountPath: /var/www/pkg.jenkins.io.staging/
   affinity:
@@ -71,11 +67,9 @@ spec:
               - linux
   restartPolicy: "Never"
   volumes:
-# This file storage is currently broken, we have an open issue with Azure
-# so I am disabling it until find a solution
-#    - name: binary-core-packages
-#      persistentVolumeClaim:
-#        claimName: binary-core-packages
+    - name: binary-core-packages
+      persistentVolumeClaim:
+        claimName: binary-core-packages
     - name: website-core-packages
       persistentVolumeClaim:
         claimName: website-core-packages

--- a/PodTemplates.d/package-windows
+++ b/PodTemplates.d/package-windows
@@ -40,10 +40,8 @@ spec:
       - name: core-packages
         mountPath: 'C:/Packages'
     volumeMounts:
-# This file storage is currently broken, we have an open issue with Azure
-# so I am disabling it until find a solution
-#      - name: binary-core-packages
-#        mountPath: /Packages/binary
+      - name: binary-core-packages
+        mountPath: /Packages/binary
       - name: website-core-packages
         mountPath: /Packages/web
   affinity:
@@ -61,11 +59,9 @@ spec:
       value: "windows"
       effect: "NoSchedule"
   volumes:
-# This file storage is currently broken, we have an open issue with Azure
-# so I am disabling it until find a solution
-#    - name: binary-core-packages
-#      persistentVolumeClaim:
-#        claimName: binary-core-packages
+    - name: binary-core-packages
+      persistentVolumeClaim:
+        claimName: binary-core-packages
     - name: website-core-packages
       persistentVolumeClaim:
         claimName: website-core-packages

--- a/PodTemplates.d/package-windows
+++ b/PodTemplates.d/package-windows
@@ -40,8 +40,10 @@ spec:
       - name: core-packages
         mountPath: 'C:/Packages'
     volumeMounts:
-      - name: binary-core-packages
-        mountPath: /Packages/binary
+# This file storage is currently broken, we have an open issue with Azure
+# so I am disabling it until find a solution
+#      - name: binary-core-packages
+#        mountPath: /Packages/binary
       - name: website-core-packages
         mountPath: /Packages/web
   affinity:
@@ -64,8 +66,6 @@ spec:
 #    - name: binary-core-packages
 #      persistentVolumeClaim:
 #        claimName: binary-core-packages
-    - name: binary-core-packages
-      emptyDir: {}
     - name: website-core-packages
       persistentVolumeClaim:
         claimName: website-core-packages


### PR DESCRIPTION
Once this PR is merged, artifacts will be pushed to the azure file storage  used by get.jenkins.io again but I propose to wait for the coming release to be done to not slow down the process