### PR TITLE
Merge master branch changes into stable-2.263

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -82,7 +82,7 @@ pipeline {
     GPG_FILE                  = 'jenkins-release.gpg'
     GPG_PASSPHRASE            = credentials('release-gpg-passphrase')
     PACKAGING_GIT_REPOSITORY  = 'git@github.com:jenkinsci/packaging.git'
-    PACKAGING_GIT_BRANCH      = 'master'
+    PACKAGING_GIT_BRANCH      = 'stable-2.263'
     SIGN_KEYSTORE_FILENAME    = 'jenkins.pfx'
     SIGN_STOREPASS            = credentials('signing-cert-pass')
     WAR_FILENAME              = 'jenkins.war'

--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -82,7 +82,7 @@ pipeline {
     GPG_FILE                  = 'jenkins-release.gpg'
     GPG_PASSPHRASE            = credentials('release-gpg-passphrase')
     PACKAGING_GIT_REPOSITORY  = 'git@github.com:jenkinsci/packaging.git'
-    PACKAGING_GIT_BRANCH      = 'INFRA-910-core-release-automation'
+    PACKAGING_GIT_BRANCH      = 'master'
     SIGN_KEYSTORE_FILENAME    = 'jenkins.pfx'
     SIGN_STOREPASS            = credentials('signing-cert-pass')
     WAR_FILENAME              = 'jenkins.war'

--- a/PodTemplates.d/package-linux
+++ b/PodTemplates.d/package-linux
@@ -67,9 +67,13 @@ spec:
               - linux
   restartPolicy: "Never"
   volumes:
+# This file storage is currently broken, we have an open issue with Azure
+# so I am disabling it until find a solution
+#    - name: binary-core-packages
+#      persistentVolumeClaim:
+#        claimName: binary-core-packages
     - name: binary-core-packages
-      persistentVolumeClaim:
-        claimName: binary-core-packages
+      emptyDir: {}
     - name: website-core-packages
       persistentVolumeClaim:
         claimName: website-core-packages

--- a/PodTemplates.d/package-windows
+++ b/PodTemplates.d/package-windows
@@ -8,7 +8,7 @@ metadata:
     jenkins/default-release-jenkins-agent: true
 spec:
   containers:
-  - image: "jenkins/inbound-agent:windowsservercore-1809"
+  - image: "jenkins/inbound-agent:4.3-9-windowsservercore-1809"
     imagePullPolicy: "Always"
     name: "jnlp"
     resources:
@@ -59,9 +59,13 @@ spec:
       value: "windows"
       effect: "NoSchedule"
   volumes:
+# This file storage is currently broken, we have an open issue with Azure
+# so I am disabling it until find a solution
+#    - name: binary-core-packages
+#      persistentVolumeClaim:
+#        claimName: binary-core-packages
     - name: binary-core-packages
-      persistentVolumeClaim:
-        claimName: binary-core-packages
+      emptyDir: {}
     - name: website-core-packages
       persistentVolumeClaim:
         claimName: website-core-packages

--- a/utils/release.sh
+++ b/utils/release.sh
@@ -432,6 +432,7 @@ function stageRelease(){
     "-DstagingRepository=${MAVEN_REPOSITORY_NAME}::default::${MAVEN_REPOSITORY_URL}/${MAVEN_REPOSITORY_NAME}" \
     -s settings-release.xml \
     --no-transfer-progress \
+    -DdeployAtEnd=true \
     -Darguments=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
     release:stage
 }
@@ -455,6 +456,7 @@ function performRelease(){
   mvn -B \
     -s settings-release.xml \
     --no-transfer-progress \
+    -DdeployAtEnd=true \
     -Darguments=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
     release:perform
 }


### PR DESCRIPTION
The stable-2.263 branch needs all changes from master.

* Invalidate fastly cache during packaging process
* Parametrized FASTLY_SERVICE_ID
* By default build windows package
* Set deloyAtEnd from maven-deploy-plugin
* Display RELEASELINE in the packaging plan
* Use specific version of the Windows container (#107)
* Hacktoberfest - Update to use master branch
* Disabling binary-core-packages volume for packaging
* Use emptyDir instead

The differences between this branch and master are correct as far as I can tell.  They show that it will use the MAVEN_REPOSITORY_NAME 'releases'.  That is the same maven repository name used for the previous stable releases.  As far as I can tell from reviewing https://repos.jenkins-ci.org/ there is no maven repository name 'releases-stable'.

```
$ git diff master
diff --git a/profile.d/stable b/profile.d/stable
index e3696af..f047b46 100644
--- a/profile.d/stable
+++ b/profile.d/stable
@@ -2,16 +2,19 @@
 # WARNING: Any variables defined here, override those defined from the Jenkinsfile
 #
 #
-RELEASE_GIT_BRANCH=master
 RELEASE_GIT_REPOSITORY=git@github.com:jenkinsci/jenkins.git
 GIT_EMAIL=66998184+jenkins-release-bot@users.noreply.github.com
 GIT_NAME="Jenkins Release Bot"
 GPG_KEYNAME="62A9756BFD780C377CF24BA8FCEF32E745F2C3D5"
 GPG_VAULT_NAME="jenkins-release-pgp"
 MAVEN_REPOSITORY_URL='https://repo.jenkins-ci.org'
-MAVEN_REPOSITORY_NAME=releases-stable
 MAVEN_PUBLIC_JENKINS_REPOSITORY_MIRROR_URL='http://nexus/repository/jenkins-public/'
 SIGN_ALIAS=jenkins

 # Used by jenkinsci/packaging
 RELEASELINE=-stable
+
+# Custom Parameters
+RELEASE_GIT_BRANCH=stable-2.263
+MAVEN_REPOSITORY_NAME=releases
+JENKINS_VERSION=2.263.1 # Only create packages for version 2.263.1
```