### PR TITLE
Add stable-rc profile

### DIFF
--- a/Jenkinsfile.d/core/stable-rc
+++ b/Jenkinsfile.d/core/stable-rc
@@ -1,0 +1,29 @@
+pipeline {
+
+  agent {
+    kubernetes {
+      label 'release-stable'
+    }
+  }
+
+  options {
+    disableConcurrentBuilds()
+  }
+
+  stages {
+    stage("Release"){
+      steps {
+        build job: "core/release/${ BRANCH_NAME }", parameters: [
+          string(name: "RELEASE_PROFILE", value: "stable-rc")
+        ]
+      }
+    }
+    stage("Package"){
+      steps {
+        build job: "core/package/${ BRANCH_NAME }", parameters: [
+          string(name: "RELEASE_PROFILE", value: "stable-rc"),
+        ]
+      }
+    }
+  }
+}

--- a/README.adoc
+++ b/README.adoc
@@ -311,6 +311,28 @@ You can re-trigger individually the two downstream jobs, release and packaging.
 - Re-triggering the packaging job won't published artifacts if they already exist but it will update website html.
 ====
 
+=== Stable Release Candidate
+A stable release-candidate is a manually triggered release that happens around once a month.
+It uses parameters defined in this link:https://github.com/jenkins-infra/release/blob/master/profile.d/stable-rc[file].
+
+Before triggering a new stable release candidatae release, some steps are required:
+
+. Prepare `jenkinsci/jenkins` repository -> missing documentation link.
+. Create a branch on jenkins-infra/release with a branch name that match the release branch from jenkinsci/jenkins like `rc-stable-<jenkins_version>`.
+. Review and update the stable environment https://github.com/jenkins-infra/release/blob/master/profile.d/stable[file] with:
+.. `RELEASE_GIT_BRANCH` set to the `jenkinsci/jenkins` release branch like `stable-2.235`
+.. `PACKAGING_GIT_BRANCH` set to the appropriated `jenkinsci/packaging` branch
+. Trigger the stable link:https://release.ci.jenkins.io/blue/organizations/jenkins/core%2Fstable%2Frelease/branches/[job]
+
+[NOTE]
+====
+You can re-trigger individually the two downstream jobs, release and packaging.
+
+- Re-triggering the release will do a version bump then push new artifacts.
+- Re-triggering the packaging job won't published artifacts if they already exist but it will update website html.
+====
+
+
 === Stable
 A stable release is a manually triggered release that happens around once a month.
 Refer to link:https://www.jenkins.io/download/lts/[LTS Release Line] for more detailed information.

--- a/README.adoc
+++ b/README.adoc
@@ -320,7 +320,7 @@ Before triggering a new stable release candidatae release, some steps are requir
 . Prepare `jenkinsci/jenkins` repository -> missing documentation link.
 . Create a branch on jenkins-infra/release with a branch name that match the release branch from jenkinsci/jenkins like `rc-stable-<jenkins_version>`.
 . Review and update the stable environment https://github.com/jenkins-infra/release/blob/master/profile.d/stable[file] with:
-.. `RELEASE_GIT_BRANCH` set to the `jenkinsci/jenkins` release branch like `rc-stable-2.235`
+.. `RELEASE_GIT_BRANCH` set to the `jenkinsci/jenkins` release branch like `stable-2.235`
 .. `PACKAGING_GIT_BRANCH` set to the appropriate `jenkinsci/packaging` branch, e.g. `stable-2.235`
 . Trigger the stable link:https://release.ci.jenkins.io/blue/organizations/jenkins/core%2Fstable%2Frelease/branches/[job]
 

--- a/README.adoc
+++ b/README.adoc
@@ -321,7 +321,7 @@ Before triggering a new stable release candidatae release, some steps are requir
 . Create a branch on jenkins-infra/release with a branch name that match the release branch from jenkinsci/jenkins like `rc-stable-<jenkins_version>`.
 . Review and update the stable environment https://github.com/jenkins-infra/release/blob/master/profile.d/stable[file] with:
 .. `RELEASE_GIT_BRANCH` set to the `jenkinsci/jenkins` release branch like `rc-stable-2.235`
-.. `PACKAGING_GIT_BRANCH` set to the appropriated `jenkinsci/packaging` branch
+.. `PACKAGING_GIT_BRANCH` set to the appropriate `jenkinsci/packaging` branch, e.g. `stable-2.235`
 . Trigger the stable link:https://release.ci.jenkins.io/blue/organizations/jenkins/core%2Fstable%2Frelease/branches/[job]
 
 [NOTE]

--- a/README.adoc
+++ b/README.adoc
@@ -320,7 +320,7 @@ Before triggering a new stable release candidatae release, some steps are requir
 . Prepare `jenkinsci/jenkins` repository -> missing documentation link.
 . Create a branch on jenkins-infra/release with a branch name that match the release branch from jenkinsci/jenkins like `rc-stable-<jenkins_version>`.
 . Review and update the stable environment https://github.com/jenkins-infra/release/blob/master/profile.d/stable[file] with:
-.. `RELEASE_GIT_BRANCH` set to the `jenkinsci/jenkins` release branch like `stable-2.235`
+.. `RELEASE_GIT_BRANCH` set to the `jenkinsci/jenkins` release branch like `rc-stable-2.235`
 .. `PACKAGING_GIT_BRANCH` set to the appropriated `jenkinsci/packaging` branch
 . Trigger the stable link:https://release.ci.jenkins.io/blue/organizations/jenkins/core%2Fstable%2Frelease/branches/[job]
 

--- a/profile.d/stable-rc
+++ b/profile.d/stable-rc
@@ -1,0 +1,22 @@
+#
+# WARNING: Any variables defined here, override those defined from the Jenkinsfile
+#
+#
+RELEASE_GIT_BRANCH=master
+RELEASE_GIT_REPOSITORY=git@github.com:jenkinsci/jenkins.git
+GIT_EMAIL=66998184+jenkins-release-bot@users.noreply.github.com
+GIT_NAME="Jenkins Release Bot"
+GPG_KEYNAME="62A9756BFD780C377CF24BA8FCEF32E745F2C3D5"
+GPG_VAULT_NAME="jenkins-release-pgp"
+MAVEN_REPOSITORY_URL='https://repo.jenkins-ci.org'
+MAVEN_REPOSITORY_NAME=snapshots
+SIGN_ALIAS=jenkins
+
+# Using JENKINS_VERSION set to latest, means that we won't try to parse every versions available from the repository
+# but instead looking at the value for metadata.versioning.latest from the maven-metadata.xml
+# this approach doesn't allow to use the same maven-repository than weekly releases.
+#
+JENKINS_VERSION=latest 
+
+# Used by jenkinsci/packaging
+RELEASELINE=-stable-rc


### PR DESCRIPTION
This PR adds a new profile for the stable candidate releases.

The key elements are:
* maven release will use the "snapshot" repository
* Every distribution packages will be published to get.jenkins.io/<distribution>-stable-rc
* JENKINS_VERSION used for distribution packaging will use the latest Jenkins version from the snaphost repository 

Once merged, we need to configure release.ci to uses "stable-rc" jenkinsfile which is defined [here](https://github.com/jenkins-infra/charts/blob/master/config/default/jenkins-release.yaml)


Signed-off-by: Olivier Vernin <olivier@vernin.me>