### PR TITLE
Fix weekly packaging job

### DIFF
--- a/Jenkinsfile.d/core/stable
+++ b/Jenkinsfile.d/core/stable
@@ -22,7 +22,6 @@ pipeline {
       steps {
         build job: "core/package/${ BRANCH_NAME }", parameters: [
           string(name: "RELEASE_PROFILE", value: "stable"),
-          string(name: "JENKINS_VERSION", value: "stable")
         ]
       }
     }

--- a/Jenkinsfile.d/core/weekly
+++ b/Jenkinsfile.d/core/weekly
@@ -30,7 +30,7 @@ pipeline {
         build job: "core/package/${ BRANCH_NAME }", parameters: [
           booleanParam(name: "VALIDATION_ENABLED", value: false),
           string(name: "RELEASE_PROFILE", value: "weekly"),
-          string(name: "JENKINS_VERSION", value: "weekly")
+          string(name: "JENKINS_VERSION", value: "latest")
         ]
       }
     }

--- a/utils/getJenkinsVersion.py
+++ b/utils/getJenkinsVersion.py
@@ -37,7 +37,7 @@ def get_latest_version(versions):
                     if int(values[i]) not in solutions:
                         solutions.append(int(values[i]))
                 except Exception:
-                    print("Ignoring version {}".format(values[i]))
+                    continue
 
         if not solutions:
             break


### PR DESCRIPTION
In this PR #104 , I updated the getJenkinsVersion.py script to retrieve the latest version when JENKINS_VERSION is set to 'latest' instead of 'weekly', unfortunately, I forgot to update the  weekly packaging job with JENKINS_VERSION set to latest. 

This PR also includes minor fixes
-> stable packaging job doesn't set JENKINS_VERSION as it shouldn't be configured there but instead in the profile file
-> `utils/getJenkinsVersion.py` doesn't print error message, if it detect a bad version pattern, instead it just skip it