### PR TITLE
Fix various shellcheck errors

### DIFF
--- a/utils/release.bash
+++ b/utils/release.bash
@@ -240,10 +240,8 @@ function guessGitBranchInformation(){
   #BRANCH_NAME="master"
 
   ## If needed, set BRANCH_NAME
-  if [ -z "$BRANCH_NAME" ];then
-    DEFAULT_BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"
-    : "${BRANCH_NAME:=$DEFAULT_BRANCH_NAME}"
-  fi
+  DEFAULT_BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD || echo 'master')"
+  : "${BRANCH_NAME:=$DEFAULT_BRANCH_NAME}"
 
   BRANCH_NAME="${BRANCH_NAME//-/ }"
   IFS=" " read -r -a array <<< "$BRANCH_NAME"


### PR DESCRIPTION
Based on the discussion we had yesterday, I propose following fixes

**Move variable PROMOTE_STAGING_MAVEN_ARTIFACTS_ARGS**
It didn't make sense to set up that variable in every situation considering that it's only use in one place in one scenario of the packaging

**Correctly double-quotes variables**

**Split when calling command from variable substitution**[
doc](https://tldp.org/LDP/abs/html/parameter-substitution.html)
set -e doesn't work in command substitution like `:${VARIABLE:=$(false)}`, instead I first default `DEFAULT_VARIABLE="$(false)"` then do `:${VARIABLE:=$DEFAULT_VARIABLE}` so we can catch errors early

**Correctly convert variable to array**

**Correctly exit in case of errors**

While I tested the following modification manually, I can't guarantee the result on release.ci :smiley: 



Signed-off-by: Olivier Vernin <olivier@vernin.me>