### PR TITLE
Merge master changes to stable-2.289

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
@@ -21,11 +21,11 @@ This role should rotate between LTS releases
 
 - [ ] LTS baseline discussed and selected in the [Jenkins developers mailing list](https://groups.google.com/g/jenkinsci-dev)
 
-- [ ] Create or update release branch in [jenkinsci/jenkins](https://github.com/jenkinsci/jenkins), e.g. `stable-2.263`
+- [ ] Create or update release branch in [jenkinsci/jenkins](https://github.com/jenkinsci/jenkins), e.g. `stable-2.277`
 
-- [ ] Create or update release branch in [jenkins-infra/release](https://github.com/jenkins-infra/release), e.g. `stable-2.263`
+- [ ] Create or update release branch in [jenkins-infra/release](https://github.com/jenkins-infra/release), e.g. `stable-2.277`
 
-- [ ] Create or update release branch in [jenkinsci/packaging](https://github.com/jenkinsci/packaging), e.g. `stable-2.263`
+- [ ] Create or update release branch in [jenkinsci/packaging](https://github.com/jenkinsci/packaging), e.g. `stable-2.277`
 
 - [ ] Create pull request to update [bom](https://github.com/jenkinsci/bom) to the weekly version that will be the base of the release line (strike this out for new point release)
 
@@ -33,13 +33,13 @@ This role should rotate between LTS releases
 
 - [ ] Review Jira and GitHub pull requests for additional LTS candidates, adding the 'lts-candidate' label, and ensure that all tickets are resolved in jira
 
-- [ ] Backporting announcement email - [script](https://github.com/jenkins-infra/backend-commit-history-parser/blob/master/bin/generate-backporting-announcement)
+- [ ] Backporting announcement email - [generate-backporting-announcement script](https://github.com/jenkins-infra/backend-commit-history-parser/blob/master/bin/generate-backporting-announcement)
 
-- [ ] Update jira labels with the selected issues, e.g. `2.263.2-fixed`, `2.263.2-rejected`
+- [ ] Update jira labels with the selected issues, e.g. `2.277.2-fixed`, `2.277.2-rejected`
 
-- [ ] Backport changes, create a local branch in jenkinsci/jenkins, run the [script](https://github.com/jenkins-infra/backend-commit-history-parser/blob/master/bin/list-issue-commits) to locate commits via jira ID, some manual work is required to locate them if the issue ID wasn't present at merge time, backport with `git cherry-pick -x $commit`
+- [ ] Backport changes, create a local branch in jenkinsci/jenkins, run the [list-issue-commits script](https://github.com/jenkins-infra/backend-commit-history-parser/blob/master/bin/list-issue-commits) to locate commits via jira ID, some manual work is required to locate them if the issue ID wasn't present at merge time, backport with `git cherry-pick -x $commit`
 
-- [ ] Open backporting PR with into-lts label and summary of changes in description from [script](https://github.com/jenkins-infra/backend-commit-history-parser/blob/master/bin/lts-candidate-stats)
+- [ ] Open backporting PR with into-lts label and summary of changes in description from [lts-candidate-stats script](https://github.com/jenkins-infra/backend-commit-history-parser/blob/master/bin/lts-candidate-stats) and the selected [Jira lts-candidates](https://issues.jenkins-ci.org/issues/?filter=12146)
 
 - [ ] Review ATH, bom and configuration-as-code integration tests results
 
@@ -51,9 +51,9 @@ This role should rotate between LTS releases
 
 - [ ] Merge backporting PR in jenkinci/jenkins using a merge commit (do not squash)
 
-- [ ] Create or update release branch in [jenkins-infra/release](https://github.com/jenkins-infra/release), e.g. `stable-2.263`.
+- [ ] Create or update release branch in [jenkins-infra/release](https://github.com/jenkins-infra/release), e.g. `stable-2.277`.
 
-- [ ] Create or update packaging branch in [jenkinsci/packaging]([jenkinsci/packaging](https://github.com/jenkinsci/packaging)), e.g. `stable-2.263`
+- [ ] Create or update packaging branch in [jenkinsci/packaging](https://github.com/jenkinsci/packaging), e.g. `stable-2.277`
 
 - [ ] Run job on [release.ci.jenkins.io](https://release.ci.jenkins.io/job/core/job/stable-rc)
 
@@ -79,7 +79,7 @@ This role should rotate between LTS releases
 
 - [ ] Confirm the [Red Hat installer acceptance test](https://ci.jenkins.io/job/Infra/job/acceptance-tests/job/install-lts-redhat-rpm/) is passing
 
-- [ ] Adjust state of all [Jira issues](https://issues.jenkins.io/) fixed in the release (see the [changelog](https://www.jenkins.io/changelog-stable) for issue links)
+- [ ] Adjust state of [Jira issues](https://issues.jenkins.io/) fixed in the release (see the [changelog](https://www.jenkins.io/changelog-stable) for issue links) and remove the `lts-candidate` label from [Jira issues resolved in the release](https://issues.jenkins.io/issues/?jql=labels%20%3D%20lts-candidate%20and%20status%20in%20(closed%2C%20resolved)%20ORDER%20BY%20status%20DESC%2C%20key%20ASC)
 
 - [ ] Create pull request to update [bom](https://github.com/jenkinsci/bom) to the newly released version
 

--- a/README.adoc
+++ b/README.adoc
@@ -275,12 +275,11 @@ The release profile is used to identify the kind of release we are going to do. 
 . Do we want to releases based on different repository branch?
 . Do we want to release based on different git repository?
 
-At the moment we identify four release type
+At the moment we identify three release types:
 
 . Weekly
 . Stable
-. Security
-. Lts security
+. Security (both weekly and LTS)
 
 [NOTE]
 ====
@@ -359,15 +358,14 @@ You can re-trigger individually the two downstream jobs, release and packaging.
 === Security
 The security release follows the same process as the stable one except that artifacts are published in private. So we need to promote git commits from a private repository to the public one then promote maven artifacts from a private maven repository to the public one.
 
-. Prepare jenkinsci-cert/jenkins repository -> missing documentation link
-. Create a branch on jenkins-infra/release with a branch name that match the release branch from jenkins-cert/jenkins like `security-stable-2.135`
-. Review and update the security environment https://github.com/jenkins-infra/release/blob/master/profile.d/security[file] with:
+. Prepare jenkinsci-cert/jenkins and create a Maven staging repository as documented by the security team.
+. Create a branch on jenkins-infra/release with a branch name corresponding to the specific release, e.g. `security-2.287` or `security-stable-2.277.2`.
+. Review and update the security environment https://github.com/jenkins-infra/release/blob/master/profile.d/security[file] with the following (new) entries:
 .. `RELEASE_GIT_BRANCH` set to the `jenkinsci-cert/jenkins` release branch like `security-stable-2.135`
-.. `PACKAGING_GIT_BRANCH` set to the appropriated jenkinsci/packaging branch
 .. `MAVEN_REPOSITORY_NAME` set to the maven repository name where we are going to publish staging maven artifacts. This is also the source location used by the packaging job to build distribution packages
 .. `JENKINS_VERSION` set to the final release version that will be packaged. If set to 'stable' or 'latest' then the packaging job will try to guess the version based on what was pushed to the maven repository. cfr settings.
-.. `RELEASELINE` set to '-stable' for a lts release otherwise leave empty
-. Trigger the generic Release link:https://release.ci.jenkins.io/job/core/job/release/[job] from the appropriated branch like `security-stable-2.235`
+.. `RELEASELINE` set to '-stable' for an LTS release, otherwise leave empty.
+. To stage the Maven artifacts, trigger the generic Release link:https://release.ci.jenkins.io/job/core/job/release/[job] from the appropriated branch like `security-stable-2.277.2`
 .. Force repository scan
 .. Trigger the first build to have access to job parameter and immediately abort it
 .. Trigger a job with the correct parameters
@@ -375,13 +373,13 @@ The security release follows the same process as the stable one except that arti
 ... `RELEASE_GIT_BRANCH` set to `unused` as we already define it in the release profile file, which overrides the job parameter
 ... `MAVEN_REPOSITORY_NAME` set to `unused` as we already define it in the release profile file, which overrides the job parameter
 ... `VALIDATION_ENABLED` set to true if the validation stage should run
-.. Trigger the generic Packaging job link:https://release.ci.jenkins.io/job/core/job/package/[job] from the appropriate branch like `security-stable-2.235` with correct parameters
+.. To create and publish packages, trigger the generic Packaging job link:https://release.ci.jenkins.io/job/core/job/package/[job] from the appropriate branch like `security-stable-2.277.2` with correct parameters
 ... `RELEASE_PROFILE` set to `security`
 ... `RELEASE_GIT_BRANCH`  set to `unused` same reason as before
 ... `MAVEN_REPOSITORY_NAME` set to `unused` same reason as before
 ... `MAVEN_REPOSITORY_PRODUCTION_NAME` set to `unused`
-... `MAVEN_STAGING_REPOSITORY_PROMOTION_ENABLED` set to true
-... `GIT_STAGING_REPOSITORY_PROMOTION_ENABLED` set to false as we prefer to do it manually once everything is done
+... `MAVEN_STAGING_REPOSITORY_PROMOTION_ENABLED` set to false (manually done by publishing-tool in a parallel process)
+... `GIT_STAGING_REPOSITORY_PROMOTION_ENABLED` set to false (manually merged by security team)
 ... `VALIDATION_ENABLED` set to true
 
 [NOTE]

--- a/utils/release.bash
+++ b/utils/release.bash
@@ -48,7 +48,8 @@ function configureGPG(){
   requireGPGPassphrase
   if ! gpg --fingerprint "${GPG_KEYNAME}"; then
     if [ ! -f "${GPG_FILE}" ]; then
-      exit "${GPG_KEYNAME} or ${GPG_FILE} cannot be found"
+      echo "${GPG_KEYNAME} or ${GPG_FILE} cannot be found"
+      exit 1
     else
       gpg --list-keys
       if [ ! -f "$HOME/.gnupg/gpg.conf" ]; then touch "$HOME/.gnupg/gpg.conf"; fi
@@ -69,7 +70,8 @@ function configureKeystore(){
   requireKeystorePass
 
   if [ ! -f "${SIGN_CERTIFICATE}" ]; then
-      exit "${SIGN_CERTIFICATE} not found"
+      echo "${SIGN_CERTIFICATE} not found"
+      exit 1
   fi
 
   case "$SIGN_CERTIFICATE" in
@@ -83,7 +85,7 @@ function configureKeystore(){
     *.pfx )
       # pfx file download from azure key vault are not password protected, which is required for maven release plugin
       # so we need to add a new password
-      openssl pkcs12 -in ${SIGN_CERTIFICATE} -out tmpjenkins.pem -nodes -passin pass:""
+      openssl pkcs12 -in "${SIGN_CERTIFICATE}" -out tmpjenkins.pem -nodes -passin pass:""
       openssl pkcs12 -export \
         -out "$SIGN_KEYSTORE" \
         -in tmpjenkins.pem \
@@ -237,10 +239,12 @@ function guessGitBranchInformation(){
   #BRANCH_NAME="stable-2.235"
   #BRANCH_NAME="master"
 
+  ## If needed, set BRANCH_NAME
+  DEFAULT_BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD || echo 'master')"
+  : "${BRANCH_NAME:=$DEFAULT_BRANCH_NAME}"
 
-  : "${BRANCH_NAME:=$(git rev-parse --abbrev-ref HEAD)}"
-
-  array=(${BRANCH_NAME//-/ })
+  BRANCH_NAME="${BRANCH_NAME//-/ }"
+  IFS=" " read -r -a array <<< "$BRANCH_NAME"
 
   if [[ "${#array[@]}" == 3 ]] ; then
     echo "Based on branch $BRANCH_NAME, expect a security release"
@@ -353,7 +357,16 @@ function prepareRelease(){
 function promoteStagingMavenArtifacts(){
   printf "\\n Promote Maven Artifacts\\n\\n"
 
-  PROMOTE_STAGING_MAVEN_ARTIFACTS_ARGS=($PROMOTE_STAGING_MAVEN_ARTIFACTS_ARGS)
+  # Following line will copy every items from source to destination,
+  # keeps in mind that it won't delete from source and override on destination if already exist!.
+  # It's wise to disable delete permission on destination repository
+  # as explained here https://www.jfrog.com/confluence/display/JFROG/Permissions#Permissions-RepositoryPermissions
+  DEFAULT_PROMOTE_STAGING_MAVEN_ARTIFACTS_ARGS="item --mode copy --source $MAVEN_REPOSITORY_NAME --destination $MAVEN_REPOSITORY_PRODUCTION_NAME --url $MAVEN_REPOSITORY_URL --username $MAVEN_REPOSITORY_USERNAME --password $MAVEN_REPOSITORY_PASSWORD --search '/org/jenkins-ci/main' $(jv get)}"
+
+  : "${PROMOTE_STAGING_MAVEN_ARTIFACTS_ARGS:=$DEFAULT_PROMOTE_STAGING_MAVEN_ARTIFACTS_ARGS}"
+
+  # Convert to array
+  IFS=" " read -r -a PROMOTE_STAGING_MAVEN_ARTIFACTS_ARGS <<< "$PROMOTE_STAGING_MAVEN_ARTIFACTS_ARGS"
 
   ../utils/promoteMavenArtifacts.py "${PROMOTE_STAGING_MAVEN_ARTIFACTS_ARGS[@]}"
 
@@ -371,7 +384,7 @@ function promoteStagingGitRepository(){
   pushd "$RELEASE_GIT_STAGING_REPOSITORY_PATH"
 
   # Clone production repository on a specific branch
-  git clone --branch $RELEASE_GIT_PRODUCTION_BRANCH "$RELEASE_GIT_PRODUCTION_REPOSITORY" .
+  git clone --branch "$RELEASE_GIT_PRODUCTION_BRANCH" "$RELEASE_GIT_PRODUCTION_REPOSITORY" .
 
   # Fetch commits from staging repository
   git fetch "$RELEASE_GIT_STAGING_REPOSITORY" "$RELEASE_GIT_STAGING_BRANCH"
@@ -514,7 +527,8 @@ EOF
 
 function syncMirror(){
 
-  PKGSERVER_SSH_OPTS=($PKGSERVER_SSH_OPTS)
+  # Convert PKGSERVER_SSH_OPTS to an array
+  IFS=" " read -r -a PKGSERVER_SSH_OPTS <<< "$PKGSERVER_SSH_OPTS"
   ssh "${PKGSERVER_SSH_OPTS[@]}" "$PKGSERVER" /srv/releases/sync.sh
 }
 
@@ -573,6 +587,8 @@ function main(){
 
 : "${ROOT_DIR:=$(dirname "$(dirname "$0")")}"
 
+# disable shellcheck warning
+# shellcheck source=/dev/null
 source "${ROOT_DIR}/profile.d/$RELEASE_PROFILE"
 
 # https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html
@@ -630,11 +646,6 @@ export RELEASE_PROFILE
 export RELEASELINE
 export JENKINS_VERSION
 
-# Following line will copy every items from source to destination,
-# keeps in mind that it won't delete from source and override on destination if already exist!.
-# It's wise to disable delete permission on destination repository
-# as explained here https://www.jfrog.com/confluence/display/JFROG/Permissions#Permissions-RepositoryPermissions
-: "${PROMOTE_STAGING_MAVEN_ARTIFACTS_ARGS:=item --mode copy --source $MAVEN_REPOSITORY_NAME --destination $MAVEN_REPOSITORY_PRODUCTION_NAME --url $MAVEN_REPOSITORY_URL --username $MAVEN_REPOSITORY_USERNAME --password $MAVEN_REPOSITORY_PASSWORD --search '/org/jenkins-ci/main' $(jv get)}"
 
 if [ ! -d "$WORKING_DIRECTORY" ]; then
   mkdir -p "$WORKING_DIRECTORY"


### PR DESCRIPTION
## Merge master branch improvements to stable-2.289

Since the master branch is used for weekly releases, it is good to reduce the differences between the master branch and the stable branch.

- Fix shellcheck errors
- Update utils/release.bash
- Expand variable before read converts it to array
- Improve security documentation
- Extend checklist item to include lts-candidate label removal (#146)
- Link to the lts-candidate Jira filter (#147)
- Fix broken link in release checklist
- Name scripts in the checklist (#152)
