### PR TITLE
chore: merges latest changes back to stable-2.289

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
@@ -55,11 +55,11 @@ This role should rotate between LTS releases
 
 - [ ] Create or update packaging branch in [jenkinsci/packaging](https://github.com/jenkinsci/packaging), e.g. `stable-2.277`
 
-- [ ] Run job on [release.ci.jenkins.io](https://release.ci.jenkins.io/job/core/job/stable-rc)
+- [ ] Deploy a release candidate built from your local machine, `mvn -e clean deploy -DskipTests=true`
 
 - [ ] Publish a pre-release [Github release](https://github.com/jenkinsci/jenkins/releases), currently we don't have a changelog for RCs
 
-- [ ] Send announcement email
+- [ ] Send announcement email, [example](https://groups.google.com/g/jenkinsci-dev/c/ox6SCyOQLuE/m/C-dsLZ4vBwAJ)
 
 - [ ] Check with security team that no security update is planned.  If a security update is planned, revise the checklist after the public pre-announcement to the [jenkinsci-advisories mailing list](https://groups.google.com/g/jenkinsci-advisories)
 

--- a/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
@@ -21,7 +21,7 @@ This role should rotate between LTS releases
 
 - [ ] LTS baseline discussed and selected in the [Jenkins developers mailing list](https://groups.google.com/g/jenkinsci-dev)
 
-- [ ] Create or update release branch in [jenkinsci/jenkins](https://github.com/jenkinsci/jenkins), e.g. `stable-2.277`
+- [ ] Create or update release branch in [jenkinsci/jenkins](https://github.com/jenkinsci/jenkins), e.g. `stable-2.277`, use the [init-lts-line](https://github.com/jenkins-infra/backend-commit-history-parser/blob/master/bin/init-lts-line) script
 
 - [ ] Create or update release branch in [jenkins-infra/release](https://github.com/jenkins-infra/release), e.g. `stable-2.277`
 

--- a/PodTemplates.d/package-windows
+++ b/PodTemplates.d/package-windows
@@ -37,12 +37,10 @@ spec:
       privileged: false
     tty: false
     volumeMounts:
-      - name: core-packages
-        mountPath: 'C:/Packages'
       - name: binary-core-packages
-        mountPath: /Packages/binary
+        mountPath: 'C:\Packages\binary'
       - name: website-core-packages
-        mountPath: /Packages/web
+        mountPath: 'C:\Packages\web'
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/PodTemplates.d/package-windows
+++ b/PodTemplates.d/package-windows
@@ -39,7 +39,6 @@ spec:
     volumeMounts:
       - name: core-packages
         mountPath: 'C:/Packages'
-    volumeMounts:
       - name: binary-core-packages
         mountPath: /Packages/binary
       - name: website-core-packages


### PR DESCRIPTION
This PR merges back to stable-2.289 the 4 last changes from the principal branch.

It includes:

* Windows Packaging fixes: 2 commits, https://github.com/jenkins-infra/release/commit/2d1f11145a1490e116f323fa7fdd19877e6917bc and https://github.com/jenkins-infra/release/commit/92dde3d7af5f869a31644a0ea65d27fe0333eacd around the Windows pod templates for agents in charge of the Windows packaging
*  Add init-lts-line script reference (#162) 
*  Fix RC build instructions (#161) 