### PR TITLE
Fix: switch microsoft Docker images to their new registry name

### DIFF
--- a/PodTemplates.d/package-linux
+++ b/PodTemplates.d/package-linux
@@ -11,7 +11,7 @@ spec:
     env:
     - name: "HOME"
       value: "/home/jenkins/agent/workspace"
-    image: "microsoft/azure-cli:2.0.59"
+    image: "mcr.microsoft.com/azure-cli:2.0.59"
     imagePullPolicy: "IfNotPresent"
     name: "azure-cli"
     resources:

--- a/PodTemplates.d/release-linux.yaml
+++ b/PodTemplates.d/release-linux.yaml
@@ -11,7 +11,7 @@ spec:
     env:
     - name: "HOME"
       value: "/home/jenkins/agent/workspace"
-    image: "microsoft/azure-cli:2.0.59"
+    image: "mcr.microsoft.com/azure-cli:2.0.59"
     imagePullPolicy: "IfNotPresent"
     name: "azure-cli"
     resources:


### PR DESCRIPTION
```shell
➜ docker pull microsoft/azure-cli:2.0.59
Error response from daemon: pull access denied for microsoft/azure-cli, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
➜ docker pull mcr.microsoft.com/azure-cli:2.0.59
2.0.59: Pulling from azure-cli
ff3a5c916c92: Already exists 
471170bb1257: Already exists 
d487cc70216e: Already exists 
9358b3ca3321: Already exists 
d4d73eb5841d: Already exists 
da1be03b2fb6: Pull complete 
4a8b316e2b85: Pull complete 
551cee3868ea: Pull complete 
1d46de139b47: Pull complete 
95bb479797b2: Pull complete 
564dbcb5ac84: Pull complete 
Digest: sha256:86a74ce97b1c37798400847dba8e135adb016068fc4d758cc3d80c90e7a6bf5a
Status: Downloaded newer image for mcr.microsoft.com/azure-cli:2.0.59
mcr.microsoft.com/azure-cli:2.0.59
```

Related to https://github.com/jenkins-infra/pipeline-library/pull/218