### PR TITLE
Check release & packaging branch before build

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
@@ -67,7 +67,7 @@ This role should rotate between LTS releases
 
 - [ ] Publish changelog (one day prior to the release in case of a security update)
 
-- [ ] Assure that contents of master branch have been merged to the stable-2.277 branch in the [release repository](https://github.com/jenkins-infra/release)
+- [ ] Assure that contents of master branch have been merged to the stable branch in the [release repository](https://github.com/jenkins-infra/release), e.g. `stable-2.277`
 
 - [ ] Assure that contents of master branch have been merged to the stable-2.277 branch in the [packaging repository](https://github.com/jenkinsci/packaging)
 

--- a/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
@@ -67,6 +67,10 @@ This role should rotate between LTS releases
 
 - [ ] Publish changelog (one day prior to the release in case of a security update)
 
+- [ ] Assure that contents of master branch have been merged to the stable-2.277 branch in the [release repository](https://github.com/jenkins-infra/release)
+
+- [ ] Assure that contents of master branch have been merged to the stable-2.277 branch in the [packaging repository](https://github.com/jenkinsci/packaging)
+
 - [ ] Run job on [release.ci.jenkins.io](https://release.ci.jenkins.io/blue/organizations/jenkins/core%2Fstable%2Frelease/branches/)
 
 - [ ] Check [LTS changelog](https://www.jenkins.io/changelog-stable/) is visible on the downloads site

--- a/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
@@ -69,7 +69,7 @@ This role should rotate between LTS releases
 
 - [ ] Assure that contents of master branch have been merged to the stable branch in the [release repository](https://github.com/jenkins-infra/release), e.g. `stable-2.277`
 
-- [ ] Assure that contents of master branch have been merged to the stable-2.277 branch in the [packaging repository](https://github.com/jenkinsci/packaging)
+- [ ] Assure that contents of master branch have been merged to the stable branch in the [packaging repository](https://github.com/jenkinsci/packaging), e.g. `stable-2.277`
 
 - [ ] Run job on [release.ci.jenkins.io](https://release.ci.jenkins.io/blue/organizations/jenkins/core%2Fstable%2Frelease/branches/)
 


### PR DESCRIPTION
Noted during the release of 2.289.3 that we need the stable-2.289 branch in the release repository to include the latest fixes from the master branch.