### PR TITLE
Retain history of 15 packaging builds

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -67,6 +67,7 @@ pipeline {
 
   options {
     disableConcurrentBuilds()
+    buildDiscarder logRotator(numToKeepStr: '15') // Retain only last 15 builds to reduce space requirements
   }
 
 //  ENV JENKINS_VERSION


### PR DESCRIPTION
## Retain 15 packaging builds on the master branch

The packaging build history consumes the majority of the space in the release.ci.jenkins.io Jenkins home directory.  Retain the most recent 15 builds on the master branch in case we need to refer to history, but don't retain anything beyond that.

Does not change the retention of logs from the release build job, just the release packaging job.  Does not change the retention of logs on any of the other packaging branches.

Space use for the master branch packaging history is 10x more than the space use of any other job on the system.
