### PR TITLE
Update branch for 4.11.2 release

### DIFF
--- a/profile.d/components/remoting
+++ b/profile.d/components/remoting
@@ -1,4 +1,4 @@
-RELEASE_GIT_BRANCH=master
+RELEASE_GIT_BRANCH=v4.11.x
 RELEASE_GIT_REPOSITORY=git@github.com:jenkinsci/remoting.git
 GIT_EMAIL=66998184+jenkins-release-bot@users.noreply.github.com
 GIT_NAME="Jenkins Release Bot"


### PR DESCRIPTION
Implementing https://github.com/jenkinsci/remoting/pull/489#issuecomment-978426556, point to https://github.com/jenkinsci/remoting/tree/v4.11.x to get 4.11.2.