### PR TITLE
chore: replace git.io link

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -15,7 +15,7 @@ pipeline {
         'stable-rc',
         'security'
       ],
-      description: 'Define which Jenkins Release we are packaging for. https://git.io/Jv7Nr',
+      description: 'Define which Jenkins Release we are packaging for. https://github.com/jenkins-infra/release/tree/master/profile.d',
       name: 'RELEASE_PROFILE'
     )
     string(

--- a/Jenkinsfile.d/core/release
+++ b/Jenkinsfile.d/core/release
@@ -22,7 +22,7 @@ pipeline {
         'stable-rc',
         'weekly'
       ],
-      description: 'Define which release profile we are going to use. https://git.io/Jv7Nr',
+      description: 'Define which release profile we are going to use. https://github.com/jenkins-infra/release/tree/master/profile.d',
       name: 'RELEASE_PROFILE'
     )
     string(


### PR DESCRIPTION
https://github.blog/changelog/2022-04-25-git-io-deprecation/