### PR TITLE
Build weekly releases with Java 11

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -82,6 +82,7 @@ pipeline {
     AZURE_VAULT_TENANT_ID     = credentials('azure-vault-tenant-id')
     GPG_FILE                  = 'jenkins-release.gpg'
     GPG_PASSPHRASE            = credentials('release-gpg-passphrase')
+    JAVA_VERSION              = "${params.RELEASE_PROFILE == 'weekly' ? '11' : '8'}"
     PACKAGING_GIT_REPOSITORY  = 'git@github.com:jenkinsci/packaging.git'
     PACKAGING_GIT_BRANCH      = 'master'
     SIGN_KEYSTORE_FILENAME    = 'jenkins.pfx'
@@ -190,6 +191,10 @@ pipeline {
               }
             }
             stage('Publish'){
+              environment {
+                JAVA_HOME = "/opt/jdk-${env.JAVA_VERSION}"
+                PATH = "${env.JAVA_HOME}/bin:${env.PATH}"
+              }
               steps {
                 sshagent(['pkgserver']) {
                   sh '''

--- a/Jenkinsfile.d/core/release
+++ b/Jenkinsfile.d/core/release
@@ -56,6 +56,7 @@ pipeline {
     AZURE_VAULT_TENANT_ID         = credentials('azure-vault-tenant-id')
     GPG_PASSPHRASE                = credentials('release-gpg-passphrase')
     GPG_FILE                      = 'jenkins-release.gpg'
+    JAVA_VERSION                  = "${params.RELEASE_PROFILE == 'weekly' ? '11' : '8'}"
     MAVEN_REPOSITORY_USERNAME     = credentials('maven-repository-username')
     MAVEN_REPOSITORY_PASSWORD     = credentials('maven-repository-password')
     SIGN_STOREPASS                = credentials('signing-cert-pass')
@@ -133,6 +134,10 @@ pipeline {
       }
     }
     stage('Stage Release') {
+      environment {
+        JAVA_HOME = "/opt/jdk-${env.JAVA_VERSION}"
+        PATH = "${env.JAVA_HOME}/bin:${env.PATH}"
+      }
       steps {
         sh '''
           utils/release.bash --stageRelease

--- a/utils/release.bash
+++ b/utils/release.bash
@@ -429,7 +429,7 @@ function stageRelease(){
   # 2020-06-24: --no-transfer-progress doesn't seem to be fully suported in maven release plugin
   # This workaround can be reverted once MRELEASE-1048 is fixed
   # https://issues.apache.org/jira/browse/MRELEASE-1048
-  mvn -B \
+  mvn -V -B \
     "-DstagingRepository=${MAVEN_REPOSITORY_NAME}::default::${MAVEN_REPOSITORY_URL}/${MAVEN_REPOSITORY_NAME}" \
     -s settings-release.xml \
     --no-transfer-progress \


### PR DESCRIPTION
Preparation for doing weekly releases with Java 11. This PR cannot be merged until after Jenkins core adopts Java 11 (currently scheduled for June for weekly releases). Implements Proposal A from https://github.com/jenkins-infra/helpdesk/issues/2945#issuecomment-1130346674. Additionally adds printing of the Java version being used to ease debugging.

### Testing done

I did not run this actual Pipeline job, but I tested my syntax with the following simple job:

```groovy
pipeline {
  agent any
  parameters {
    choice(
        choices: ['weekly', 'stable', 'stable-rc', 'security'],
        description: 'Define which Jenkins Release we are packaging for. https://github.com/jenkins-infra/release/tree/master/profile.d',
        name: 'RELEASE_PROFILE'
        )
  }

  environment {
    JAVA_VERSION = "${params.RELEASE_PROFILE == 'weekly' ? '11' : '8'}"
  }

  stages {
    stage('Build') {
      environment {
        JAVA_HOME = "/opt/jdk-${env.JAVA_VERSION}"
        PATH = "${env.JAVA_HOME}/bin:${env.PATH}"
      }
      steps {
        sh 'env | grep JAVA'
        sh 'env | grep PATH'
      }
    }
  }
}
```

I verified that this simple job printed the expected values for `JAVA_HOME` and `PATH` when run with both `weekly` and `stable` as the input parameters.