### PR TITLE
Release signed remoting from stable-4.13.x branch, not master branch

### DIFF
--- a/profile.d/components/remoting
+++ b/profile.d/components/remoting
@@ -1,3 +1,4 @@
+# Releases from the master branch now use JEP-229, not this release process
 RELEASE_GIT_BRANCH=stable-4.13.x
 RELEASE_GIT_REPOSITORY=git@github.com:jenkinsci/remoting.git
 GIT_EMAIL=66998184+jenkins-release-bot@users.noreply.github.com


### PR DESCRIPTION
## Release signed remoting from stable-4.13.x branch

Remoting releases from older baselines (like stable-4.13.x) need to deliver a signed jar file for compatibility. This pull request changes the default branch used for remoting releases from release.ci.jenkins.io to use the stable-4.13.x branch instead of the master branch.

Remoting releases on the remoting master branch no longer require a signed jar file with the removal of Java Web Start in https://github.com/jenkinsci/remoting/pull/532

The release.ci.jenkins.io job that delivers remoting with signed jars is no longer used for releases of the master branch of the remoting repository.

This change should allow us to deliver remoting 4.13.1.  Remoting releases from the master branch will continue to use JEP-229 as was done for https://github.com/jenkinsci/remoting/releases/tag/3020.vcc32c3b_cc767
