### PR TITLE
fix(release) Rely on the Docker image `PATH` to locate the default `java` binary

### DIFF
--- a/PodTemplates.d/package-windows.yaml
+++ b/PodTemplates.d/package-windows.yaml
@@ -8,7 +8,7 @@ metadata:
     jenkins/default-release-jenkins-agent: true
 spec:
   containers:
-  - image: "jenkins/inbound-agent:4.3-9-windowsservercore-1809"
+  - image: "jenkins/inbound-agent:4.13-2-jdk11-nanoserver-1809"
     imagePullPolicy: "Always"
     name: "jnlp"
     resources:

--- a/PodTemplates.d/release-linux.yaml
+++ b/PodTemplates.d/release-linux.yaml
@@ -14,8 +14,6 @@ spec:
           value: "/home/jenkins/agent/workspace"
         - name: "MAVEN_OPTS"
           value: "-Xmx8g -Xms8g"
-        - name: "JENKINS_JAVA_BIN"
-          value: "/opt/jdk-11/bin/java"
       resources:
         limits:
           memory: "16Gi"


### PR DESCRIPTION
- https://github.com/jenkins-infra/docker-packaging/pull/36 removed JDK8 and changed the `JAVA_HOME` value
- #237 and #232 changed the Docker image but we forgot to update the pod config


This PR also bumps the package windowsagent remoting version to use recent ones