### PR TITLE
fix(release) use openssl legacy provider for pkcs12

### DIFF
--- a/utils/release.bash
+++ b/utils/release.bash
@@ -77,6 +77,7 @@ function configureKeystore(){
   case "$SIGN_CERTIFICATE" in
     *.pem )
       openssl pkcs12 -export \
+        -provider legacy `# https://github.com/openssl/openssl/issues/11672` \
         -out "$SIGN_KEYSTORE" \
         -in "${SIGN_CERTIFICATE}" \
         -password "pass:$SIGN_STOREPASS" \
@@ -85,8 +86,14 @@ function configureKeystore(){
     *.pfx )
       # pfx file download from azure key vault are not password protected, which is required for maven release plugin
       # so we need to add a new password
-      openssl pkcs12 -in "${SIGN_CERTIFICATE}" -out tmpjenkins.pem -nodes -passin pass:""
+      openssl pkcs12 \
+        -in "${SIGN_CERTIFICATE}" \
+        -provider legacy `# https://github.com/openssl/openssl/issues/11672` \
+        -out tmpjenkins.pem \
+        -nodes \
+        -passin pass:""
       openssl pkcs12 -export \
+        -provider legacy `# https://github.com/openssl/openssl/issues/11672` \
         -out "$SIGN_KEYSTORE" \
         -in tmpjenkins.pem \
         -password "pass:$SIGN_STOREPASS" \


### PR DESCRIPTION
Ref. https://github.com/openssl/openssl/issues/11672.
This is a short-term measure to fix the weekly release process.

This PR aims at fixing the error message:

```console
+ openssl pkcs12 <redacted>
Error outputting keys and certificates
40270330917F0000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:../crypto/evp/evp_fetch.c:349:Global default library context, Algorithm (RC2-40-CBC : 0), Properties ()
```