### PR TITLE
Display Maven version information without stopping build

### DIFF
--- a/utils/release.bash
+++ b/utils/release.bash
@@ -436,7 +436,7 @@ function stageRelease(){
   # 2020-06-24: --no-transfer-progress doesn't seem to be fully suported in maven release plugin
   # This workaround can be reverted once MRELEASE-1048 is fixed
   # https://issues.apache.org/jira/browse/MRELEASE-1048
-  mvn -B \
+  mvn -V -B \
     "-DstagingRepository=${MAVEN_REPOSITORY_NAME}::default::${MAVEN_REPOSITORY_URL}/${MAVEN_REPOSITORY_NAME}" \
     -s settings-release.xml \
     --no-transfer-progress \


### PR DESCRIPTION
See also https://github.com/jenkinsci/packaging/pull/309. This PR adds the `-V` argument when invoking Maven, which displays the version of Maven and Java used in the build without stopping the build, which could be useful for debugging purposes (especially as we switch builds to Java 11).