### PR TITLE
chore(Jenkinsfiles) remove deprecated label directive for kubernetes agent definitions

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -255,7 +255,6 @@ pipeline {
               // as the step 'container' is known to not be working
               agent {
                 kubernetes {
-                  label 'packaging-windows'
                   yamlFile 'PodTemplates.d/package-windows.yaml'
                 }
               }

--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -1,7 +1,6 @@
 pipeline {
   agent {
     kubernetes {
-      label 'package-linux'
       yamlFile 'PodTemplates.d/package-linux.yaml'
       workingDir '/home/jenkins/agent'
     }

--- a/Jenkinsfile.d/core/release
+++ b/Jenkinsfile.d/core/release
@@ -9,7 +9,6 @@
 pipeline {
   agent {
     kubernetes {
-      label 'release-linux'
       yamlFile 'PodTemplates.d/release-linux.yaml'
     }
   }

--- a/Jenkinsfile.d/core/stable
+++ b/Jenkinsfile.d/core/stable
@@ -2,7 +2,6 @@ pipeline {
 
   agent {
     kubernetes {
-      label 'release-stable'
     }
   }
 

--- a/Jenkinsfile.d/core/stable-rc
+++ b/Jenkinsfile.d/core/stable-rc
@@ -2,7 +2,6 @@ pipeline {
 
   agent {
     kubernetes {
-      label 'release-stable-rc'
     }
   }
 

--- a/Jenkinsfile.d/core/weekly
+++ b/Jenkinsfile.d/core/weekly
@@ -2,7 +2,6 @@ pipeline {
 
   agent {
     kubernetes {
-      label 'release-weekly'
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/jenkins-infra/helpdesk/issues/2979

Using `label` in the `agent {}` section in a Jenkinsfile only make sense for `node`, `docker` or `dockerfile` , as per https://www.jenkins.io/doc/book/pipeline/syntax/#common-options.
