### PR TITLE
Revert Ubuntu 22.04/ JDK8-removal changes for stable 2.332

### DIFF
--- a/PodTemplates.d/package-linux.yaml
+++ b/PodTemplates.d/package-linux.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: jnlp
-      image: jenkinsciinfra/packaging:2.1.41
+      image: jenkinsciinfra/packaging:2.1.32
       imagePullPolicy: "IfNotPresent"
       env:
         - name: "HOME"

--- a/PodTemplates.d/release-linux.yaml
+++ b/PodTemplates.d/release-linux.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: jnlp
-      image: jenkinsciinfra/packaging:2.1.41
+      image: jenkinsciinfra/packaging:2.1.32
       imagePullPolicy: "IfNotPresent"
       env:
         - name: "HOME"

--- a/PodTemplates.d/release-linux.yaml
+++ b/PodTemplates.d/release-linux.yaml
@@ -14,6 +14,8 @@ spec:
           value: "/home/jenkins/agent/workspace"
         - name: "MAVEN_OPTS"
           value: "-Xmx8g -Xms8g"
+        - name: "JENKINS_JAVA_BIN"
+          value: "/opt/jdk-11/bin/java"
       resources:
         limits:
           memory: "16Gi"

--- a/utils/release.bash
+++ b/utils/release.bash
@@ -77,7 +77,6 @@ function configureKeystore(){
   case "$SIGN_CERTIFICATE" in
     *.pem )
       openssl pkcs12 -export \
-        -legacy `# https://github.com/openssl/openssl/issues/11672` \
         -out "$SIGN_KEYSTORE" \
         -in "${SIGN_CERTIFICATE}" \
         -password "pass:$SIGN_STOREPASS" \
@@ -86,14 +85,8 @@ function configureKeystore(){
     *.pfx )
       # pfx file download from azure key vault are not password protected, which is required for maven release plugin
       # so we need to add a new password
-      openssl pkcs12 \
-        -in "${SIGN_CERTIFICATE}" \
-        -legacy `# https://github.com/openssl/openssl/issues/11672` \
-        -out tmpjenkins.pem \
-        -nodes \
-        -passin pass:""
+      openssl pkcs12 -in "${SIGN_CERTIFICATE}" -out tmpjenkins.pem -nodes -passin pass:""
       openssl pkcs12 -export \
-        -legacy `# https://github.com/openssl/openssl/issues/11672` \
         -out "$SIGN_KEYSTORE" \
         -in tmpjenkins.pem \
         -password "pass:$SIGN_STOREPASS" \


### PR DESCRIPTION
- https://github.com/jenkins-infra/docker-packaging/compare/2.1.9...2.1.32
- Using the latest image as posible to benefits from @basil 's work on the systemd macros: is this LTS the correct target?
- Reverted the openssl command (related to Ubuntu 22.04) change
- Reverted the java bin path for spawning the inbound agent


```shell
$ docker run --rm -ti --entrypoint=openssl jenkinsciinfra/packaging:2.1.32 pkcs12 --help 2>&1 | grep legacy
$ docker run --rm -ti --entrypoint=openssl jenkinsciinfra/packaging:2.1.41 pkcs12 --help 2>&1 | grep legacy
 -legacy             Use legacy encryption: 3DES_CBC for keys, RC2_CBC for certs
$ docker run --rm -ti --entrypoint=/opt/jdk-11/bin/java jenkinsciinfra/packaging:2.1.32 -version                        
openjdk version "11.0.13" 2021-10-19
OpenJDK Runtime Environment Temurin-11.0.13+8 (build 11.0.13+8)
OpenJDK 64-Bit Server VM Temurin-11.0.13+8 (build 11.0.13+8, mixed mode)
$ docker run --rm -ti --entrypoint=/opt/jdk-8/bin/java jenkinsciinfra/packaging:2.1.32 -version
openjdk version "1.8.0_312"
OpenJDK Runtime Environment (Temurin)(build 1.8.0_312-b07)
OpenJDK 64-Bit Server VM (Temurin)(build 25.312-b07, mixed mode)
```