### PR TITLE
docs: Exclude bom updates for point releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
@@ -87,6 +87,7 @@ This role should rotate between LTS releases
 - [ ] Adjust state and `Released As` of [Jira issues](https://issues.jenkins.io/) fixed in the release (see the [changelog](https://www.jenkins.io/changelog-stable) for issue links)
 
 - [ ] Create pull request to update [bom](https://github.com/jenkinsci/bom) to the newly released version
+  (strike this out for new point release)
 
 - [ ] Create pull request to update [configuration-as-code integration tests](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/integrations/pom.xml) to the newly released version
 


### PR DESCRIPTION
According to https://github.com/jenkinsci/bom/blob/master/sample-plugin/pom.xml#L518 this step does no longer apply for point releases.