### PR TITLE
Remove dead code for `-DdeployAtEnd=true`

### DIFF
--- a/utils/release.bash
+++ b/utils/release.bash
@@ -440,7 +440,6 @@ function stageRelease(){
     "-DstagingRepository=${MAVEN_REPOSITORY_NAME}::default::${MAVEN_REPOSITORY_URL}/${MAVEN_REPOSITORY_NAME}" \
     -s settings-release.xml \
     --no-transfer-progress \
-    -DdeployAtEnd=true \
     -Darguments=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
     release:stage
 }
@@ -464,7 +463,6 @@ function performRelease(){
   mvn -B \
     -s settings-release.xml \
     --no-transfer-progress \
-    -DdeployAtEnd=true \
     -Darguments=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
     release:perform
 }


### PR DESCRIPTION
### Problem

If you have access to it, take a look at e.g. https://release.ci.jenkins.io/job/core/job/release/job/master/169/consoleFull and search for `maven-deploy-plugin`. `maven-deploy-plugin` is not invoked at the end but rather sequentially within each module, indicating the passed-in option is clearly not taking effect. As such it is dead code, and dead code is generally a maintenance burden.

### Evaluation

The `release:stage` and/or `release:perform` invocations don't run the deploy task directly, but rather they fork a new copy of Maven in the `run-perform-goals` stage. That copy of Maven gets its arguments from whatever is passed to `-Darguments` in the main Maven process, which does not include `-DdeployAtEnd=true`. As such the `-DdeployAtEnd=true` only applies to a parent process that never invokes the `deploy` goal, and it is dead code.

### Solution

[Flense](https://en.wikipedia.org/wiki/Flensing) it. While it would be possible to try and implement deploying at the end by adding `-DdeployAtEnd` to the `argument` property, that carries non-zero risk. Since the existing status quo is working good enough, we deemed it safer to change the code to reflect the actual execution of the status quo rather than to change the execution to reflect the theoretical intention of the code.