### PR TITLE
fix(Jenkins Pipelines) do not allocate agent for "parent" pipelines and retry the packaging process a 2nd time

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -3,6 +3,7 @@ pipeline {
     kubernetes {
       yamlFile 'PodTemplates.d/package-linux.yaml'
       workingDir '/home/jenkins/agent'
+      retries 2 // Retry in case of agent error caused by controller restart or pod deletion for instance
     }
   }
 
@@ -66,7 +67,6 @@ pipeline {
   options {
     disableConcurrentBuilds()
     buildDiscarder logRotator(numToKeepStr: '15') // Retain only last 15 builds to reduce space requirements
-    retry(conditions: [agent(), kubernetesAgent(handleNonKubernetes: true), nonresumable()], count: 2)
   }
 
 //  ENV JENKINS_VERSION

--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -66,6 +66,7 @@ pipeline {
   options {
     disableConcurrentBuilds()
     buildDiscarder logRotator(numToKeepStr: '15') // Retain only last 15 builds to reduce space requirements
+    retry(conditions: [agent(), kubernetesAgent(handleNonKubernetes: true), nonresumable()], count: 2)
   }
 
 //  ENV JENKINS_VERSION

--- a/Jenkinsfile.d/core/release
+++ b/Jenkinsfile.d/core/release
@@ -11,7 +11,6 @@ pipeline {
   agent {
     kubernetes {
       yamlFile 'PodTemplates.d/release-linux.yaml'
-      retries 2 // Retry in case of agent error caused by controller restart or pod deletion for instance
     }
   }
 

--- a/Jenkinsfile.d/core/release
+++ b/Jenkinsfile.d/core/release
@@ -4,12 +4,14 @@
   Jenkins Plugins:
     * Azure-Credentials
     * SSH-agent
+    * Kubernetes
 */
 
 pipeline {
   agent {
     kubernetes {
       yamlFile 'PodTemplates.d/release-linux.yaml'
+      retries 2 // Retry in case of agent error caused by controller restart or pod deletion for instance
     }
   }
 
@@ -45,7 +47,6 @@ pipeline {
 
   options {
     disableConcurrentBuilds()
-    retry(conditions: [agent(), kubernetesAgent(handleNonKubernetes: true), nonresumable()], count: 2)
   }
 
   environment {

--- a/Jenkinsfile.d/core/release
+++ b/Jenkinsfile.d/core/release
@@ -45,6 +45,7 @@ pipeline {
 
   options {
     disableConcurrentBuilds()
+    retry(conditions: [agent(), kubernetesAgent(handleNonKubernetes: true), nonresumable()], count: 2)
   }
 
   environment {

--- a/Jenkinsfile.d/core/stable
+++ b/Jenkinsfile.d/core/stable
@@ -1,9 +1,5 @@
 pipeline {
-
-  agent {
-    kubernetes {
-    }
-  }
+  agent none
 
   options {
     disableConcurrentBuilds()

--- a/Jenkinsfile.d/core/stable-rc
+++ b/Jenkinsfile.d/core/stable-rc
@@ -1,9 +1,5 @@
 pipeline {
-
-  agent {
-    kubernetes {
-    }
-  }
+  agent none
 
   options {
     disableConcurrentBuilds()

--- a/Jenkinsfile.d/core/weekly
+++ b/Jenkinsfile.d/core/weekly
@@ -1,9 +1,5 @@
 pipeline {
-
-  agent {
-    kubernetes {
-    }
-  }
+  agent none
 
   options {
     disableConcurrentBuilds()


### PR DESCRIPTION
Closes https://github.com/jenkins-infra/helpdesk/issues/2925

This PR introduces 2 min changes:

- Stop allocating a node for the "top-level" job: it will run in a "ligthweight executor" (e.g. a JVM thread) in the controller which is expected to survive controller restart. Less moving pieces, less code, less resource usage.
- Enable the "retry" top-level directive thanks to @jglick's recent work. This directive ensures that in most usual cases (sush as a controller restart), the pipeline shoud *resume*. Tested manually: if the `sh` step was started, then it continues the pipeline when resuming.
  - There are still some edge cases where the pipeline does not resume: if the pipeline instruction is not durable.

