### PR TITLE
Feat: Init 2.361.2

### DIFF
--- a/profile.d/stable
+++ b/profile.d/stable
@@ -15,4 +15,4 @@ SIGN_ALIAS=jenkins
 
 # Used by jenkinsci/packaging
 RELEASELINE=-stable
-JENKINS_VERSION=2.361.1
+JENKINS_VERSION=2.361.2


### PR DESCRIPTION
Create or update release branch in [jenkins-infra/release](https://github.com/jenkins-infra/release), e.g. stable-2.361:

- [x] Modify the `RELEASE_GIT_BRANCH` (i.e., stable-2.361) and `JENKINS_VERSION` (i.e., 2.361.2) values in the environment file (profile.d/stable) to match the release.
- [x] Modify the `PACKAGING_GIT_BRANCH` (i.e., stable-2.361) value in the packaging script (`Jenkinsfile.d/core/package`) to match the release.