### PR TITLE
Replace IRC with bridged channels

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
@@ -70,8 +70,8 @@ This role should rotate between LTS releases
 
 - [ ] Assure that contents of master branch have been merged to the stable branch in the [packaging repository](https://github.com/jenkinsci/packaging), e.g. `stable-2.361`
 
-- [ ] Announce the start of the LTS release process in the [#jenkins-infra IRC channels](https://gitter.im/jenkinsci/jenkins-infra).
-
+- [ ] Announce the start of the LTS release process in the [#jenkins-release](https://matrix.to/#/#jenkins-release:libera.chat) and [#jenkins-infra](https://matrix.to/#/#jenkins-infra:libera.chat) IRC channels
+- 
 - [ ] Run job on [release.ci.jenkins.io](https://release.ci.jenkins.io/blue/organizations/jenkins/core%2Fstable%2Frelease/branches/) if no security release for Jenkins is planned.
 
 - [ ] Check [LTS changelog](https://www.jenkins.io/changelog-stable/) is visible on the downloads site

--- a/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
@@ -70,7 +70,7 @@ This role should rotate between LTS releases
 
 - [ ] Assure that contents of master branch have been merged to the stable branch in the [packaging repository](https://github.com/jenkinsci/packaging), e.g. `stable-2.361`
 
-- [ ] Announce the start of the LTS release process in the #jenkins-release and #jenkins-infra IRC channels
+- [ ] Announce the start of the LTS release process in the [#jenkins-infra IRC channels](https://gitter.im/jenkinsci/jenkins-infra).
 
 - [ ] Run job on [release.ci.jenkins.io](https://release.ci.jenkins.io/blue/organizations/jenkins/core%2Fstable%2Frelease/branches/) if no security release for Jenkins is planned.
 

--- a/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
@@ -71,7 +71,6 @@ This role should rotate between LTS releases
 - [ ] Assure that contents of master branch have been merged to the stable branch in the [packaging repository](https://github.com/jenkinsci/packaging), e.g. `stable-2.361`
 
 - [ ] Announce the start of the LTS release process in the [#jenkins-release](https://matrix.to/#/#jenkins-release:libera.chat) and [#jenkins-infra](https://matrix.to/#/#jenkins-infra:libera.chat) IRC channels
-- 
 - [ ] Run job on [release.ci.jenkins.io](https://release.ci.jenkins.io/blue/organizations/jenkins/core%2Fstable%2Frelease/branches/) if no security release for Jenkins is planned.
 
 - [ ] Check [LTS changelog](https://www.jenkins.io/changelog-stable/) is visible on the downloads site

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: "💬 Chat"
     url: https://matrix.to/#/#jenkins-release:libera.chat
-    about: Please ask and answer questions here.
+    about: Please ask and answer questions on Matrix (#jenkins-release).
   - name: "❓ IRC"
     url: https://web.libera.chat/
     about: Click here to access IRC from a browser (#jenkins-release on libera.chat).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: "💬 Chat"
     url: https://matrix.to/#/#jenkins-release:libera.chat
     about: Please ask and answer questions on Matrix (#jenkins-release).
-  - name: "❓ IRC"
-    url: https://web.libera.chat/
-    about: Click here to access IRC from a browser (#jenkins-release on libera.chat).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: "❓ Chat"
-    url: https://gitter.im/jenkinsci/release
+  - name: "💬 Chat"
+    url: https://matrix.to/#/#jenkins-release:libera.chat
     about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,6 @@ contact_links:
   - name: "💬 Chat"
     url: https://matrix.to/#/#jenkins-release:libera.chat
     about: Please ask and answer questions here.
+  - name: "❓ IRC"
+    url: https://web.libera.chat/
+    about: Click here to access IRC from a browser (#jenkins-release on libera.chat).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: "❓ IRC"
-    url: https://web.libera.chat/
-    about: Please ask and answer questions here, (#jenkins-release on libera.chat).
+  - name: "❓ Chat"
+    url: https://gitter.im/jenkinsci/release
+    about: Please ask and answer questions here.


### PR DESCRIPTION
IRC channels are now bridged to matrix, which is bridged to gitter.
Benefits are, that it's easier to access, without the need to set up a bouncer to stay connected or read past messages, unless you are already using matrix.