### PR TITLE
fix(release script) use the new staging repository layout maven when staging a release

### DIFF
--- a/utils/release.bash
+++ b/utils/release.bash
@@ -426,18 +426,8 @@ function stageRelease(){
   printf "\\n Stage Jenkins Release\\n\\n"
   # Do not display transfer progress when downloading or uploading
   # https://maven.apache.org/ref/3.6.1/maven-embedder/cli.html
-  #mvn -B \
-  #  "-DstagingRepository=${MAVEN_REPOSITORY_NAME}::default::${MAVEN_REPOSITORY_URL}/${MAVEN_REPOSITORY_NAME}" \
-  #  -s settings-release.xml \
-  #  --no-transfer-progress \
-  #  -Darguments=--no-transfer-progress \
-  #  release:stage
-
-  # 2020-06-24: --no-transfer-progress doesn't seem to be fully suported in maven release plugin
-  # This workaround can be reverted once MRELEASE-1048 is fixed
-  # https://issues.apache.org/jira/browse/MRELEASE-1048
   mvn -V -B \
-    "-DstagingRepository=${MAVEN_REPOSITORY_NAME}::default::${MAVEN_REPOSITORY_URL}/${MAVEN_REPOSITORY_NAME}" \
+    "-DstagingRepository=${MAVEN_REPOSITORY_NAME}::${MAVEN_REPOSITORY_URL}/${MAVEN_REPOSITORY_NAME}" \
     -s settings-release.xml \
     --no-transfer-progress \
     -Darguments=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3143. (line edited at this PR does not fix any problem).

It ensures that the specified staging repository uses the new maven-deploy layout as per https://maven.apache.org/plugins/maven-deploy-plugin/#major-version-upgrade-to-version-3-0-0.

In order to merge PR, I need help by Maven expert to confirm that I'm not doing something crazy here.


Ping @basil @jglick @jnord @daniel-beck @timja @MarkEWaite you are my Maven experts 🍯 May I get your advise?