### PR TITLE
Remove dead arguments code

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -465,7 +465,7 @@ So if the process fails on running  `mvn release:stage`, then we can re-trigger 
 kubectl get pods -n release # Looking for the correct jenkins agent name
 kubectl exec -i -t -n release -c maven <pod_name alias jenkins agent> bash
 cd /home/jenkins/agent/workspace/core_release_master/release
-mvn -B -DstagingRepository=releases::default::https://repo.jenkins-ci.org/releases -s settings-release.xml --no-transfer-progress -Darguments=--no-transfer-progress release:stage
+mvn -B -DstagingRepository=releases::default::https://repo.jenkins-ci.org/releases -s settings-release.xml --no-transfer-progress release:stage
 ```
 
 == Miscellaneous

--- a/utils/release.bash
+++ b/utils/release.bash
@@ -20,15 +20,7 @@ function requireAzureKeyvaultCredentials(){
 }
 
 function clean(){
-
-    # Do not display transfer progress when downloading or uploading
-    # https://maven.apache.org/ref/3.6.1/maven-embedder/cli.html
-    # mvn -s settings-release.xml -B --no-transfer-progress -Darguments=--no-transfer-progress release:clean
-    # 2020-06-24: --no-transfer-progress doesn't seem to be fully suported in maven release plugin
-    # This workaround can be reverted once MRELEASE-1048 is fixed
-    # https://issues.apache.org/jira/browse/MRELEASE-1048
-
-    mvn -s settings-release.xml -B --no-transfer-progress -Darguments=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn release:clean
+    mvn -s settings-release.xml -B --no-transfer-progress release:clean
 }
 
 function cloneReleaseGitRepository(){
@@ -350,15 +342,7 @@ function prepareRelease(){
   generateSettingsXml
 
   printf "\\n Prepare Jenkins Release\\n\\n"
-
-  # Do not display transfer progress when downloading or uploading
-  # https://maven.apache.org/ref/3.6.1/maven-embedder/cli.html
-  #mvn -B -s settings-release.xml --no-transfer-progress -Darguments=--no-transfer-progress release:prepare
-
-  # 2020-06-24: --no-transfer-progress doesn't seem to be fully suported in maven release plugin
-  # This workaround can be reverted once MRELEASE-1048 is fixed
-  # https://issues.apache.org/jira/browse/MRELEASE-1048
-  mvn -B -s settings-release.xml --no-transfer-progress -Darguments=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn release:prepare
+  mvn -B -s settings-release.xml --no-transfer-progress release:prepare
 }
 
 function promoteStagingMavenArtifacts(){
@@ -423,47 +407,23 @@ function rollback(){
 function stageRelease(){
   requireGPGPassphrase
   requireKeystorePass
-  printf "\\n Stage Jenkins Release\\n\\n"
-  # Do not display transfer progress when downloading or uploading
-  # https://maven.apache.org/ref/3.6.1/maven-embedder/cli.html
-  #mvn -B \
-  #  "-DstagingRepository=${MAVEN_REPOSITORY_NAME}::default::${MAVEN_REPOSITORY_URL}/${MAVEN_REPOSITORY_NAME}" \
-  #  -s settings-release.xml \
-  #  --no-transfer-progress \
-  #  -Darguments=--no-transfer-progress \
-  #  release:stage
 
-  # 2020-06-24: --no-transfer-progress doesn't seem to be fully suported in maven release plugin
-  # This workaround can be reverted once MRELEASE-1048 is fixed
-  # https://issues.apache.org/jira/browse/MRELEASE-1048
+  printf "\\n Stage Jenkins Release\\n\\n"
   mvn -V -B \
     "-DstagingRepository=${MAVEN_REPOSITORY_NAME}::default::${MAVEN_REPOSITORY_URL}/${MAVEN_REPOSITORY_NAME}" \
     -s settings-release.xml \
     --no-transfer-progress \
-    -Darguments=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
     release:stage
 }
 
 function performRelease(){
   requireGPGPassphrase
   requireKeystorePass
+
   printf "\\n Perform Jenkins Release\\n\\n"
-  # Do not display transfer progress when downloading or uploading
-  # https://maven.apache.org/ref/3.6.1/maven-embedder/cli.html
-  # mvn -B \
-  #   -s settings-release.xml \
-  #   --no-transfer-progress \
-  #   -Darguments=--no-transfer-progress \
-  #   release:perform
-
-
-  # 2020-06-24: --no-transfer-progress doesn't seem to be fully suported in maven release plugin
-  # This workaround can be reverted once MRELEASE-1048 is fixed
-  # https://issues.apache.org/jira/browse/MRELEASE-1048
   mvn -B \
     -s settings-release.xml \
     --no-transfer-progress \
-    -Darguments=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
     release:perform
 }
 


### PR DESCRIPTION
The release build sets `-Darguments` in various places in a futile attempt to reduce log spam, futile because that setting is ignored due to the presence of https://github.com/jenkinsci/jenkins/blob/d25704cfbc929bca3bd5e5675e1fe1aa1a58928c/pom.xml#L429, as one can see by looking at the actual console output and seeing the log spam. And furthermore, the presence of custom arguments anywhere (either via `-Darguments` in the top-level Maven invocation or in the `maven-release-plugin` configuration in `pom.xml`) seems to break the `release:stage` goal in Maven Release Plugin 3.x as described in https://github.com/jenkins-infra/helpdesk/issues/3143#issuecomment-1254040470, so removing this dead code takes us one step closer toward working around the problem (the other step being removing the custom configuration in `pom.xml`).