### PR TITLE
Add `sign` to `<activeProfiles>`

### DIFF
--- a/utils/release.bash
+++ b/utils/release.bash
@@ -230,6 +230,7 @@ cat <<EOT> settings-release.xml
   </servers>
   <activeProfiles>
     <activeProfile>release</activeProfile>
+    <activeProfile>sign</activeProfile>
     <activeProfile>automated-release</activeProfile>
   </activeProfiles>
 </settings>


### PR DESCRIPTION
Fixes a regression exposed by jenkinsci/pom#281 and jenkinsci/jenkins#6914. In order for release artifacts to be signed by `maven-gpg-plugin` and `maven-jarsigner-plugin` during the `release:prepare` goal, we rely on https://github.com/jenkinsci/jenkins/blob/d25704cfbc929bca3bd5e5675e1fe1aa1a58928c/pom.xml#L521-L540 and https://github.com/jenkinsci/jenkins/blob/d25704cfbc929bca3bd5e5675e1fe1aa1a58928c/war/pom.xml#L623-L648, activated by the `release` and `sign` profiles respectively. To activate these profiles during the `release:prepare` goal we currently rely on https://github.com/jenkinsci/jenkins/blob/d25704cfbc929bca3bd5e5675e1fe1aa1a58928c/pom.xml#L428-L429, which happens to expose a serious bug in recent versions of Maven Release Plugin as explained in https://github.com/jenkins-infra/helpdesk/issues/3143#issuecomment-1254040470. Fortunately for us, we can work around the problem by omitting any custom arguments from our Maven Release Plugin configuration as in https://github.com/jenkins-infra/release/pull/291 and https://github.com/jenkinsci/jenkins/pull/7138, instead enabling these profiles via an `<activeProfiles>` setting in `settings-release.xml` as in this PR. Note that we cannot enable these profiles using [`releaseProfiles`](https://maven.apache.org/maven-release/maven-release-plugin/stage-mojo.html#releaseProfiles) because that setting only applies to the `release:stage` and `release:perform` goals, not the `release:prepare` goal.