### PR TITLE
chore: replace `readProperties` by a shell script

### DIFF
--- a/Jenkinsfile.d/components/remoting
+++ b/Jenkinsfile.d/components/remoting
@@ -86,8 +86,7 @@ pipeline {
           '''
 
           script {
-            def properties = readProperties file: 'release/release.properties'
-            env.RELEASE_SCM_TAG = properties['scm.tag']
+            env.RELEASE_SCM_TAG = sh(returnStdout: true, script: 'fgrep scm.tag= release/release.properties | cut -c9-').trim()
           }
         }
       }

--- a/Jenkinsfile.d/core/release
+++ b/Jenkinsfile.d/core/release
@@ -118,8 +118,7 @@ pipeline {
         '''
 
         script {
-          def properties = readProperties file: 'release/release.properties'
-          env.RELEASE_SCM_TAG = properties['scm.tag']
+          env.RELEASE_SCM_TAG = sh(returnStdout: true, script: 'fgrep scm.tag= release/release.properties | cut -c9-').trim()
         }
       }
     }


### PR DESCRIPTION
Thanks @jglick for the suggestion in https://github.com/jenkins-infra/pipeline-library/issues/523#issuecomment-1323906482

Fixes https://github.com/jenkins-infra/release/issues/313