### PR TITLE
fix(gha): use the updatecli GitHub action 'installation' mode

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -13,18 +13,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Diff
+      - name: Setup updatecli
         uses: updatecli/updatecli-action@a149459e1feb1b410600dda2203cf1ee2afebf42 # v2.24.0
-        with:
-          command: diff
-          flags: "--config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml"
+      - name: Diff
+        run: updatecli diff --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Apply
         uses: updatecli/updatecli-action@a149459e1feb1b410600dda2203cf1ee2afebf42 # v2.24.0
         if: github.ref == 'refs/heads/master'
-        with:
-          command: apply
-          flags: "--config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml"
+        run: updatecli apply --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/updatecli/updatecli.d/docker-packaging.yml
+++ b/updatecli/updatecli.d/docker-packaging.yml
@@ -66,9 +66,9 @@ targets:
       key: spec.containers[0].image
     scmid: default
 
-pullrequests:
+actions:
   default:
-    kind: github
+    kind: github/pullrequest
     scmid: default
     title: Bump `jenkinsciinfra/packaging` Docker image version to {{ source "lastVersion" }}
     spec:


### PR DESCRIPTION
Fixes the GHA which hasn't properly run since November 2022 by using the updatecli action's install mode (instead of execute in a closed environment), which removes the following warning message from the action logs:

> Unexpected input(s) 'command', 'flags', valid inputs are ['version']

Also replace deprecated directives in the updatecli manifest.

Related: https://github.com/jenkins-infra/status/pull/258
