### PR TITLE
chore: adapt pod templates to `privatek8s` nodes taints

### DIFF
--- a/PodTemplates.d/package-linux.yaml
+++ b/PodTemplates.d/package-linux.yaml
@@ -28,15 +28,6 @@ spec:
           mountPath: /srv/releases/jenkins
         - name: website-core-packages
           mountPath: /var/www/pkg.jenkins.io.staging/
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: kubernetes.io/os
-                operator: In
-                values:
-                  - linux
   volumes:
     - name: binary-core-packages
       persistentVolumeClaim:
@@ -44,3 +35,15 @@ spec:
     - name: website-core-packages
       persistentVolumeClaim:
         claimName: website-core-packages
+  nodeSelector:
+    kubernetes.azure.com/agentpool: releasepool
+    kubernetes.io/os: linux
+  tolerations:
+    - key: "os"
+      operator: "Equal"
+      value: "linux"
+      effect: "NoSchedule"
+    - key: "jenkins"
+      operator: "Equal"
+      value: "release.ci.jenkins.io"
+      effect: "NoSchedule"

--- a/PodTemplates.d/package-windows.yaml
+++ b/PodTemplates.d/package-windows.yaml
@@ -36,17 +36,15 @@ spec:
     securityContext:
       privileged: false
     tty: false
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-        - matchExpressions:
-          - key: kubernetes.io/os
-            operator: In
-            values:
-              - windows
+  nodeSelector:
+    kubernetes.azure.com/agentpool: w2019
+    kubernetes.io/os: windows
   tolerations:
     - key: "os"
       operator: "Equal"
       value: "windows"
+      effect: "NoSchedule"
+    - key: "jenkins"
+      operator: "Equal"
+      value: "release.ci.jenkins.io"
       effect: "NoSchedule"

--- a/PodTemplates.d/release-linux.yaml
+++ b/PodTemplates.d/release-linux.yaml
@@ -25,30 +25,16 @@ spec:
         privileged: false
         runAsUser: 1000
         runAsGroup: 1000
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: kubernetes.io/os
-                operator: In
-                values:
-                  - linux
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 1
-          preference:
-            matchExpressions:
-              - key: agentpool
-                operator: In
-                values:
-                  - highmemlinux
+  restartPolicy: "Never"
+  nodeSelector:
+    kubernetes.azure.com/agentpool: releasepool
+    kubernetes.io/os: linux
   tolerations:
     - key: "os"
       operator: "Equal"
       value: "linux"
       effect: "NoSchedule"
-    - key: "profile"
+    - key: "jenkins"
       operator: "Equal"
-      value: "highmem"
+      value: "release.ci.jenkins.io"
       effect: "NoSchedule"
-  restartPolicy: "Never"


### PR DESCRIPTION
This PR adapts the pod templates to the privatek8s nodes defined here: https://github.com/jenkins-infra/azure/blob/62f0ff898ec69ffe677fd7c37e3fc366f5b3e318/privatek8s.tf#L101-L138

In draft until the final phase of the release.ci.jenkins.io migration from prodpublick8s to priatek8s cluster is started.

Ref: https://github.com/jenkins-infra/helpdesk/issues/2844