### PR TITLE
Do not publish MSI

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -58,7 +58,8 @@ pipeline {
       name: 'VALIDATION_ENABLED'
     )
     booleanParam(
-      defaultValue: true,
+      // TODO: Enable Windows packaging again when code signing certificate is available
+      defaultValue: false,
       description: 'Enable Windows Packaging',
       name: 'WINDOWS_PACKAGING_ENABLED'
     )
@@ -246,55 +247,53 @@ pipeline {
             }
           }
         }
-        stage('Windows') {
-          when {
-            environment name: 'WINDOWS_PACKAGING_ENABLED', value: 'true'
-          }
-          stages {
-            stage('Build') {
-              // Windows requirement: Every steps need to be executed inside default jnlp
-              // as the step 'container' is known to not be working
-              agent {
-                kubernetes {
-                  yamlFile 'PodTemplates.d/package-windows.yaml'
-                }
-              }
-              steps {
-                container('dotnet') {
-                  checkout scm
-                  dir (WORKING_DIRECTORY){
-                    git branch: PACKAGING_GIT_BRANCH, credentialsId: 'release-key', url: PACKAGING_GIT_REPOSITORY
-
-                    unstash 'GPG'
-                    unstash 'WAR'
-                    unstash 'KEYSTORE'
-
-                    powershell '''
-                      Get-ChildItem env:
-                      $env:WAR=(Resolve-Path .\\jenkins.war).Path
-                      & .\\make.ps1
-                    '''
-                    // Don't archive the full path
-                    dir('msi\\build\\bin\\Release\\en-US') {
-                      archiveArtifacts '*.msi*'
-                    }
-
-                  }
-                }
-              }
-            }
-            stage('Publish'){
-              steps {
-                unarchive mapping: ['*.msi*': WORKING_DIRECTORY]
-                sshagent(['pkgserver']) {
-                  sh '''
-                    ./utils/release.bash --packaging msi.publish
-                  '''
-                }
-              }
-            }
-          }
-        }
+        // TODO: Enable Windows packaging again when code signing certificate is available
+        // stage('Windows') {
+        //   when {
+        //     environment name: 'WINDOWS_PACKAGING_ENABLED', value: 'true'
+        //   }
+        //   stages {
+        //     stage('Build') {
+        //       // Windows requirement: Every steps need to be executed inside default jnlp
+        //       // as the step 'container' is known to not be working
+        //       agent {
+        //         kubernetes {
+        //           yamlFile 'PodTemplates.d/package-windows.yaml'
+        //         }
+        //       }
+        //       steps {
+        //         container('dotnet') {
+        //           checkout scm
+        //           dir (WORKING_DIRECTORY){
+        //             git branch: PACKAGING_GIT_BRANCH, credentialsId: 'release-key', url: PACKAGING_GIT_REPOSITORY
+        //             unstash 'GPG'
+        //             unstash 'WAR'
+        //             unstash 'KEYSTORE'
+        //             powershell '''
+        //               Get-ChildItem env:
+        //               $env:WAR=(Resolve-Path .\\jenkins.war).Path
+        //               & .\\make.ps1
+        //             '''
+        //             // Don't archive the full path
+        //             dir('msi\\build\\bin\\Release\\en-US') {
+        //               archiveArtifacts '*.msi*'
+        //             }
+        //           }
+        //         }
+        //       }
+        //     }
+        //     stage('Publish'){
+        //       steps {
+        //         unarchive mapping: ['*.msi*': WORKING_DIRECTORY]
+        //         sshagent(['pkgserver']) {
+        //           sh '''
+        //             ./utils/release.bash --packaging msi.publish
+        //           '''
+        //         }
+        //       }
+        //     }
+        //   }
+        // }
       }
     }
     stage('Promote'){


### PR DESCRIPTION
## Do not push MSI with release

Windows MSI packaging needs a code signing certificate.  Our code signing certificate has expired.  Attorneys from Linux Foundation and Continuous Delivery Foundation are working to resolve the issues.  Don't publish an MSI until the code signing certificate is again available.

Matching pull request in the packaging repository:

* https://github.com/jenkinsci/packaging/pull/384