### PR TITLE
feat: ensure that new 2023 digicert is used + GPG 2023 passphrase

### DIFF
--- a/Jenkinsfile.d/components/remoting
+++ b/Jenkinsfile.d/components/remoting
@@ -24,7 +24,7 @@ pipeline {
       AZURE_VAULT_CLIENT_ID         = credentials('azure-vault-client-id')
       AZURE_VAULT_CLIENT_SECRET     = credentials('azure-vault-client-secret')
       AZURE_VAULT_TENANT_ID         = credentials('azure-vault-tenant-id')
-      GPG_PASSPHRASE                = credentials('release-gpg-passphrase')
+      GPG_PASSPHRASE                = credentials('release-gpg-passphrase-2023')
       GPG_FILE                      = 'jenkins-release.gpg'
       MAVEN_REPOSITORY_USERNAME     = credentials('maven-repository-username')
       MAVEN_REPOSITORY_PASSWORD     = credentials('maven-repository-password')

--- a/Jenkinsfile.d/components/remoting
+++ b/Jenkinsfile.d/components/remoting
@@ -20,7 +20,7 @@ pipeline {
 
     environment {
       AZURE_VAULT_NAME              = 'prodreleasecore'
-      AZURE_VAULT_CERT              = 'prodreleasecore'
+      AZURE_VAULT_CERT              = 'prodreleasecore-2023'
       AZURE_VAULT_CLIENT_ID         = credentials('azure-vault-client-id')
       AZURE_VAULT_CLIENT_SECRET     = credentials('azure-vault-client-secret')
       AZURE_VAULT_TENANT_ID         = credentials('azure-vault-tenant-id')
@@ -28,7 +28,7 @@ pipeline {
       GPG_FILE                      = 'jenkins-release.gpg'
       MAVEN_REPOSITORY_USERNAME     = credentials('maven-repository-username')
       MAVEN_REPOSITORY_PASSWORD     = credentials('maven-repository-password')
-      SIGN_STOREPASS                = credentials('signing-cert-pass')
+      SIGN_STOREPASS                = credentials('signing-cert-pass-2023')
       RELEASE_PROFILE               = "components/remoting"
     }
 

--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -76,7 +76,7 @@ pipeline {
 
   environment {
     AZURE_VAULT_NAME          = 'prodreleasecore'
-    AZURE_VAULT_CERT          = 'prodreleasecore'
+    AZURE_VAULT_CERT          = 'prodreleasecore-2023'
     AZURE_VAULT_CLIENT_ID     = credentials('azure-vault-client-id')
     AZURE_VAULT_CLIENT_SECRET = credentials('azure-vault-client-secret')
     AZURE_VAULT_TENANT_ID     = credentials('azure-vault-tenant-id')
@@ -85,7 +85,7 @@ pipeline {
     PACKAGING_GIT_REPOSITORY  = 'git@github.com:jenkinsci/packaging.git'
     PACKAGING_GIT_BRANCH      = 'master'
     SIGN_KEYSTORE_FILENAME    = 'jenkins.pfx'
-    SIGN_STOREPASS            = credentials('signing-cert-pass')
+    SIGN_STOREPASS            = credentials('signing-cert-pass-2023')
     WAR_FILENAME              = 'jenkins.war'
     WAR                       = "$WORKSPACE/$WORKING_DIRECTORY/$WAR_FILENAME"
     MAVEN_REPOSITORY_USERNAME = credentials('maven-repository-username')
@@ -94,7 +94,7 @@ pipeline {
     MSI                       = "$WORKSPACE/$WORKING_DIRECTORY/$MSI_FILENAME"
     WORKING_DIRECTORY         = "release"
     PKCS12_FILE               = "$WORKSPACE/$WORKING_DIRECTORY/jenkins.pfx" // Created by SIGN_KEYSTORE
-    PKCS12_PASSWORD_FILE      = credentials('signing-cert-pass')
+    PKCS12_PASSWORD_FILE      = credentials('signing-cert-pass-2023')
   }
 
   stages {

--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -81,7 +81,7 @@ pipeline {
     AZURE_VAULT_CLIENT_SECRET = credentials('azure-vault-client-secret')
     AZURE_VAULT_TENANT_ID     = credentials('azure-vault-tenant-id')
     GPG_FILE                  = 'jenkins-release.gpg'
-    GPG_PASSPHRASE            = credentials('release-gpg-passphrase')
+    GPG_PASSPHRASE            = credentials('release-gpg-passphrase-2023')
     PACKAGING_GIT_REPOSITORY  = 'git@github.com:jenkinsci/packaging.git'
     PACKAGING_GIT_BRANCH      = 'master'
     SIGN_KEYSTORE_FILENAME    = 'jenkins.pfx'

--- a/Jenkinsfile.d/core/release
+++ b/Jenkinsfile.d/core/release
@@ -54,7 +54,7 @@ pipeline {
     AZURE_VAULT_CLIENT_ID         = credentials('azure-vault-client-id')
     AZURE_VAULT_CLIENT_SECRET     = credentials('azure-vault-client-secret')
     AZURE_VAULT_TENANT_ID         = credentials('azure-vault-tenant-id')
-    GPG_PASSPHRASE                = credentials('release-gpg-passphrase')
+    GPG_PASSPHRASE                = credentials('release-gpg-passphrase-2023')
     GPG_FILE                      = 'jenkins-release.gpg'
     MAVEN_REPOSITORY_USERNAME     = credentials('maven-repository-username')
     MAVEN_REPOSITORY_PASSWORD     = credentials('maven-repository-password')

--- a/Jenkinsfile.d/core/release
+++ b/Jenkinsfile.d/core/release
@@ -50,7 +50,7 @@ pipeline {
 
   environment {
     AZURE_VAULT_NAME              = 'prodreleasecore'
-    AZURE_VAULT_CERT              = 'prodreleasecore'
+    AZURE_VAULT_CERT              = 'prodreleasecore-2023'
     AZURE_VAULT_CLIENT_ID         = credentials('azure-vault-client-id')
     AZURE_VAULT_CLIENT_SECRET     = credentials('azure-vault-client-secret')
     AZURE_VAULT_TENANT_ID         = credentials('azure-vault-tenant-id')
@@ -58,7 +58,7 @@ pipeline {
     GPG_FILE                      = 'jenkins-release.gpg'
     MAVEN_REPOSITORY_USERNAME     = credentials('maven-repository-username')
     MAVEN_REPOSITORY_PASSWORD     = credentials('maven-repository-password')
-    SIGN_STOREPASS                = credentials('signing-cert-pass')
+    SIGN_STOREPASS                = credentials('signing-cert-pass-2023')
   }
 
   stages {


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3323

Blocked by https://github.com/jenkins-infra/kubernetes-management/pull/3789

This PR follows up https://github.com/jenkins-infra/release/pull/357 and https://github.com/jenkinsci/packaging/pull/385 which enable MSI generation again.

The goal is to ensure the new Digicert cert is used to sign the MSI (and the JAR).


Please note that we also are explicitly using a year on the GPG passphrase changed last week, for homogeneity