### PR TITLE
chore: backport of #339 on `stable-2.375` to replace `readProperties` by a shell script

### DIFF
--- a/Jenkinsfile.d/components/remoting
+++ b/Jenkinsfile.d/components/remoting
@@ -86,8 +86,7 @@ pipeline {
           '''
 
           script {
-            def properties = readProperties file: 'release/release.properties'
-            env.RELEASE_SCM_TAG = properties['scm.tag']
+            env.RELEASE_SCM_TAG = sh(returnStdout: true, script: 'fgrep scm.tag= release/release.properties | cut -c9-').trim()
           }
         }
       }


### PR DESCRIPTION
Corresponding issue: https://github.com/jenkins-infra/release/issues/313

Ref: https://github.com/jenkins-infra/pipeline-library/issues/523#issuecomment-1472187331