### PR TITLE
Init LTS 2.401.3

### DIFF
--- a/profile.d/stable
+++ b/profile.d/stable
@@ -15,4 +15,4 @@ SIGN_ALIAS=jenkins
 
 # Used by jenkinsci/packaging
 RELEASELINE=-stable
-JENKINS_VERSION=2.401.2
+JENKINS_VERSION=2.401.3


### PR DESCRIPTION
Updated `JENKINS_VERSION` values in the environment file (`profile.d/stable`) to match the release.