### PR TITLE
Revise RC announcement part

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
@@ -65,7 +65,7 @@ Remember to exchange the LTS version, release date and Jira URLs.
 
 - [ ] Publish a pre-release [Github release](https://github.com/jenkinsci/jenkins/releases), e.g. [sample](https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.387.1-rc) currently we don't have a changelog for RCs.
 
-- [ ] Send announcement email, [example](https://groups.google.com/g/jenkinsci-dev/c/ox6SCyOQLuE/m/C-dsLZ4vBwAJ).
+- [ ] Confirm the automatic announcement has been sent to the [jenkinsci-dev](https://groups.google.com/g/jenkinsci-dev) mailing list and [community forums](https://community.jenkins.io/c/blog/23).
 
 - [ ] Check with security team that no security update is planned.  If a security update is planned, revise the checklist after the public pre-announcement to the [jenkinsci-advisories mailing list](https://groups.google.com/g/jenkinsci-advisories).
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -230,9 +230,9 @@ Create a pre-release on GitHub for the `stable-2.VVV` branch based on [this](htt
 
 **Note**: If you do not have write access on the repository, ask a release team member to create the pre-release for you.
 
-### Send an announcement email
+### Confirm the automatic RC announcement has been sent
 
-Send an announcement email to the jenkinsci-devforum mailing list. Use [this](https://groups.google.com/g/jenkinsci-dev/c/ox6SCyOQLuE/m/C-dsLZ4vBwAJ) example.
+The [jenkinsci-dev](https://groups.google.com/g/jenkinsci-dev) mailing list and the [community forums](https://community.jenkins.io/c/blog/23) have received an automatic announcement about the RC, once the pre-release has been created on GitHub.
 
 ### Check for security updates
 


### PR DESCRIPTION
Depends on https://github.com/jenkinsci/jenkins/pull/8282

I thought we can automate this process, given it's based on a template, essentially.

Preview from my demo repository:

![Screenshot 2023-07-19 at 10 27 02](https://github.com/jenkins-infra/release/assets/13383509/de57b319-2d3e-4a78-bdd3-ae5378896134)