### PR TITLE
Revise post LTS line creation steps

### DIFF
--- a/tools/init-lts-line
+++ b/tools/init-lts-line
@@ -39,7 +39,4 @@ cat <<EOF
 Remember to:
     Push the branch
         $ git push --set-upstream ${remote_name} ${branch_name}
-    Push the backporting announcement
-        $ generate-backporting-announcement ${baseline}.1
-    Populate community calendar
 EOF


### PR DESCRIPTION
The script in question has been removed, and the calendar is (typically) filled with dates in advance, nor does it seem that all members of the release team https://github.com/orgs/jenkins-infra/teams/release have access to it, at least, I don't.