### PR TITLE
Bump pod agent images to use JDK17 for agent processes but keep JDK11 for building Jenkins

### DIFF
--- a/PodTemplates.d/package-linux.yaml
+++ b/PodTemplates.d/package-linux.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: jnlp
-      image: jenkinsciinfra/packaging:3.0.2
+      image: jenkinsciinfra/packaging:4.0.0
       imagePullPolicy: "IfNotPresent"
       env:
         - name: "HOME"

--- a/PodTemplates.d/package-windows.yaml
+++ b/PodTemplates.d/package-windows.yaml
@@ -8,7 +8,7 @@ metadata:
     jenkins/default-release-jenkins-agent: true
 spec:
   containers:
-  - image: "jenkins/inbound-agent:4.13-2-jdk11-nanoserver-1809"
+  - image: "jenkins/inbound-agent:4.13-2-jdk17-nanoserver-1809"
     imagePullPolicy: "Always"
     name: "jnlp"
     resources:

--- a/PodTemplates.d/release-linux.yaml
+++ b/PodTemplates.d/release-linux.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: jnlp
-      image: jenkinsciinfra/packaging:3.0.2
+      image: jenkinsciinfra/packaging:4.0.0
       imagePullPolicy: "IfNotPresent"
       env:
         - name: "HOME"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3072

This PR ensures that https://github.com/jenkins-infra/docker-packaging/pull/75 (released as https://github.com/jenkins-infra/docker-packaging/releases/tag/4.0.0) is deployed.

It also ensures that Windows packaging pod agent is using JDK17 (agent process).