### PR TITLE
fix(package-windows) revert additional environment variables for `jnlp` container

### DIFF
--- a/PodTemplates.d/package-windows.yaml
+++ b/PodTemplates.d/package-windows.yaml
@@ -11,6 +11,11 @@ spec:
   - image: "jenkins/inbound-agent:3142.vcfca_0cd92128-1-jdk17-nanoserver-1809"
     imagePullPolicy: "IfNotPresent"
     name: "jnlp"
+    env:
+      - name: "JENKINS_JAVA_BIN"
+        value: "C:/openjdk-17/bin/java"
+      - name: "JENKINS_JAVA_OPTS"
+        value: '"-XX:+PrintCommandLineFlags" --show-version'
     resources:
       limits:
         memory: "4Gi"


### PR DESCRIPTION
The `JENKINS_JAVA_OPTS` variable caused errors during the `2.410` and `2.414.1` releases by failing the Windows pod allocation with a JVM flag error.

As per https://github.com/jenkinsci/docker-inbound-agent#windows-jenkins-java-opts, the double quote `"` is required for this flag

Tested with a replay: it works and the resulting value in the pod template for the environment variable is `value: "\"-XX:+PrintCommandLineFlags\" --show-version"`

(edit)

Proposal: 
- This PR is not urgent: we have until the 28 so it will be used for the 2.421 weekly
- If it works properly for the 2.421, then we'll cherry pick to `stable-2.414` (it works currently on this branch so not mandatory but nice to have except it must NOT break next time: I already broke too much things here)