### PR TITLE
Revert "Prepare security 2.424"

### DIFF
--- a/profile.d/security
+++ b/profile.d/security
@@ -26,9 +26,3 @@ RELEASE_GIT_PRODUCTION_BRANCH=master
 #         as retrieved from ./utils/getJenkinsVersion.py
 
 MAVEN_REPOSITORY_PRODUCTION_NAME=releases
-
-# Most settings above are unused
-RELEASE_GIT_BRANCH=security-master
-MAVEN_REPOSITORY_NAME=cam
-JENKINS_VERSION=2.424
-RELEASELINE=


### PR DESCRIPTION
Reverts jenkins-infra/release#435

These PRs target their own temporary branches per https://github.com/jenkins-infra/release#security (step 1)