### PR TITLE
Widen groovy import in lts-candidate-stats script

### DIFF
--- a/tools/lts-candidate-stats
+++ b/tools/lts-candidate-stats
@@ -1,4 +1,8 @@
 #!/usr/bin/env groovy
+
+// Intentional wildcard import to allow the script to run on Ubuntu 22.04 groovy and Red Hat 8.8 groovy.
+// https://github.com/jenkins-infra/release/pull/468
+// https://stackoverflow.com/questions/55169114/unable-to-add-xmlslurper-to-eclipse-groovy-project
 import groovy.xml.*;
 
 class Script {

--- a/tools/lts-candidate-stats
+++ b/tools/lts-candidate-stats
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-import groovy.xml.XmlSlurper;
+import groovy.xml.*;
 
 class Script {
 


### PR DESCRIPTION
## Widen groovy import in lts-candidate-stats script

A [stackoverflow article](https://stackoverflow.com/questions/55169114/unable-to-add-xmlslurper-to-eclipse-groovy-project) suggests widening the import.  That worked for me on Red Hat Enterprise Linux 8 with groovy 2.4.21 installed using sdkman.

No problem if this is not accepted, since I haven't tested it on any other distribution.  I needed it in my environment and can keep it on a private branch.
