### PR TITLE
Init LTS 2.426.2 release

### DIFF
--- a/profile.d/stable
+++ b/profile.d/stable
@@ -15,4 +15,4 @@ SIGN_ALIAS=jenkins
 
 # Used by jenkinsci/packaging
 RELEASELINE=-stable
-JENKINS_VERSION=2.426.1
+JENKINS_VERSION=2.426.2


### PR DESCRIPTION
Updated the JENKINS_VERSION in profile.d/stable to init LTS 2.462.2 release. 