### PR TITLE
Allow weekly build to merge before push

### DIFF
--- a/utils/release.bash
+++ b/utils/release.bash
@@ -391,7 +391,7 @@ function pushCommits() {
 	if [[ "${RELEASE_PROFILE}" = "weekly" ]]; then
 		git fetch origin
 	fi
-        git merge --no-edit "origin/${RELEASE_GIT_BRANCH}"
+	git merge --no-edit "origin/${RELEASE_GIT_BRANCH}"
 	git push origin "HEAD:${RELEASE_GIT_BRANCH}" "${RELEASE_SCM_TAG}"
 }
 

--- a/utils/release.bash
+++ b/utils/release.bash
@@ -388,7 +388,7 @@ function pushCommits() {
 	# Ensure we use ssh credentials
 	git config --get remote.origin.url
 	sed -i 's#url = https://github.com/#url = git@github.com:#' .git/config
-	if [[ "${RELEASE_PROFILE" = "weekly" ]]; then
+	if [[ "${RELEASE_PROFILE}" = "weekly" ]]; then
 		git fetch origin
 	fi
         git merge --no-edit "origin/${RELEASE_GIT_BRANCH}"

--- a/utils/release.bash
+++ b/utils/release.bash
@@ -388,7 +388,7 @@ function pushCommits() {
 	# Ensure we use ssh credentials
 	git config --get remote.origin.url
 	sed -i 's#url = https://github.com/#url = git@github.com:#' .git/config
-	if [[ "${RELEASE_PROFILE}" = "weekly" ]]; then
+	if [[ ${RELEASE_PROFILE} == "weekly" ]]; then
 		git fetch origin
 		git merge --no-edit "origin/${RELEASE_GIT_BRANCH}"
 	fi

--- a/utils/release.bash
+++ b/utils/release.bash
@@ -383,12 +383,15 @@ function promoteStagingGitRepository() {
 }
 
 function pushCommits() {
-	: "${RELEASE_SCM_TAG:?RELEASE_SCM_TAG not definded}"
+	: "${RELEASE_SCM_TAG:?RELEASE_SCM_TAG not defined}"
 
 	# Ensure we use ssh credentials
 	git config --get remote.origin.url
 	sed -i 's#url = https://github.com/#url = git@github.com:#' .git/config
-	git pull
+	if [[ "${RELEASE_PROFILE" = "weekly" ]]; then
+		git fetch origin
+	fi
+        git merge --no-edit "origin/${RELEASE_GIT_BRANCH}"
 	git push origin "HEAD:${RELEASE_GIT_BRANCH}" "${RELEASE_SCM_TAG}"
 }
 

--- a/utils/release.bash
+++ b/utils/release.bash
@@ -390,8 +390,8 @@ function pushCommits() {
 	sed -i 's#url = https://github.com/#url = git@github.com:#' .git/config
 	if [[ "${RELEASE_PROFILE}" = "weekly" ]]; then
 		git fetch origin
+		git merge --no-edit "origin/${RELEASE_GIT_BRANCH}"
 	fi
-	git merge --no-edit "origin/${RELEASE_GIT_BRANCH}"
 	git push origin "HEAD:${RELEASE_GIT_BRANCH}" "${RELEASE_SCM_TAG}"
 }
 


### PR DESCRIPTION
## Allow weekly build to merge before push

Fixes https://github.com/jenkins-infra/release/issues/387

Intentionally limited to only push if using the weekly release profile because we do not expect to receive commits during a build on a branch that is not a weekly build.  LTS builds and security builds that have a commit arrive during the build should continue to fail the build.

## Testing done

Confirmed that `git fetch origin` and `git merge --no-edit origin/master` do not create a merge commit when there is nothing to merge or when the merge is a fast forward merge.

Confirmed that `git fetch origin` and `git merge --no-edit origin/master` create a merge commit when there is a local commit.

Confirmed on release.ci.jenkins.io that `RELEASE_PROFILE` is defined for weekly releases (like 2.439) as 'weekly' and that `RELEASE_PROFILE` is defined for LTS releases as `stable`.