### PR TITLE
Remove the unused --rollback argument

### DIFF
--- a/utils/release.bash
+++ b/utils/release.bash
@@ -392,11 +392,6 @@ function pushCommits() {
 	git push origin "HEAD:${RELEASE_GIT_BRANCH}" "${RELEASE_SCM_TAG}"
 }
 
-function rollback() {
-	mvn -B -V -ntp release:rollback
-	git push --delete origin "${RELEASE_SCM_TAG}"
-}
-
 function stageRelease() {
 	requireGPGPassphrase
 	requireKeystorePass
@@ -517,7 +512,6 @@ function main() {
 			--showPackagingPlan) echo "Show Packaging Plan" && showPackagingPlan ;;
 			--promoteStagingMavenArtifacts) echo "Promote Staging Maven Artifacts" && promoteStagingMavenArtifacts ;;
 			--promoteStagingGitRepository) echo "Promote Staging Git Repository" && promoteStagingGitRepository ;;
-			--rollback) echo "Rollback release ${RELEASE_SCM_TAG}" && rollback ;;
 			--stageRelease) echo "Stage Release" && stageRelease ;;
 			--packaging) echo 'Execute packaging makefile, quote required around Makefile target' && packaging "$2" ;;
 			--syncMirror) echo 'Trigger mirror synchronization' && syncMirror ;;


### PR DESCRIPTION
## Remove the unused `--rollback` argument

No benefit to retaining unused command line arguments.

Fixes https://github.com/jenkins-infra/release/issues/488
