### PR TITLE
Init LTS 2.440.2

### DIFF
--- a/profile.d/stable
+++ b/profile.d/stable
@@ -15,4 +15,4 @@ SIGN_ALIAS=jenkins
 
 # Used by jenkinsci/packaging
 RELEASELINE=-stable
-JENKINS_VERSION=2.440.1
+JENKINS_VERSION=2.440.2


### PR DESCRIPTION
Updated the `JENKINS_VERSION` from `2.440.1` to `2.440.2`. 