### PR TITLE
chore: init LTS 2.452.3 release

### DIFF
--- a/profile.d/stable
+++ b/profile.d/stable
@@ -15,4 +15,4 @@ SIGN_ALIAS=jenkins
 
 # Used by jenkinsci/packaging
 RELEASELINE=-stable
-JENKINS_VERSION=2.452.2
+JENKINS_VERSION=2.452.3


### PR DESCRIPTION
Updated `JENKINS_VERSION` in "profile.d/stable". 