### PR TITLE
Fix sed for Linux

### DIFF
--- a/tools/init-lts-line
+++ b/tools/init-lts-line
@@ -48,9 +48,9 @@ git clone git@github.com:jenkins-infra/release.git "$release_repo"
 pushd "$release_repo"
 git checkout -b "stable-${baseline}"
 
-sed -i "" "s/PACKAGING_GIT_BRANCH      = 'master'/PACKAGING_GIT_BRANCH      = 'stable-${baseline}'/g" Jenkinsfile.d/core/package
+sed -i'' "s/PACKAGING_GIT_BRANCH      = 'master'/PACKAGING_GIT_BRANCH      = 'stable-${baseline}'/g" Jenkinsfile.d/core/package
 
-sed -i "" "s/RELEASE_GIT_BRANCH=master/RELEASE_GIT_BRANCH=stable-${baseline}/g" profile.d/stable
+sed -i'' "s/RELEASE_GIT_BRANCH=master/RELEASE_GIT_BRANCH=stable-${baseline}/g" profile.d/stable
 echo "JENKINS_VERSION=${baseline}.1" >> profile.d/stable
 
 git add Jenkinsfile.d/core/package profile.d/stable

--- a/utils/release.bash
+++ b/utils/release.bash
@@ -49,7 +49,7 @@ function configureGPG() {
 			fi
 			if ! grep -E '^pinentry-mode loopback' "${HOME}/.gnupg/gpg.conf"; then
 				if grep -E '^pinentry-mode' "${HOME}/.gnupg/gpg.conf"; then
-					sed -i '/^pinentry-mode/d' "${HOME}/.gnupg/gpg.conf"
+					sed -i'' '/^pinentry-mode/d' "${HOME}/.gnupg/gpg.conf"
 				fi
 				## --pinenty-mode is needed to avoid gpg prompt during maven release
 				echo 'pinentry-mode loopback' >>"${HOME}/.gnupg/gpg.conf"


### PR DESCRIPTION
## Fix `sed -i` for Linux

The `sed -i ""` syntax works on the BSD variants but not on Linux variants.

The `sed -i` syntax works on Linux variants but not on BSD variants (like macOS).

The `sed -i''` syntax works on both BSD variants and Linux variants.
