### PR TITLE
Revert "Disable weekly build temporarily"

### DIFF
--- a/Jenkinsfile.d/core/weekly
+++ b/Jenkinsfile.d/core/weekly
@@ -13,7 +13,20 @@ pipeline {
   stages {
     stage("Release"){
       steps {
-        echo "Release build is disabled for security fixes"
+        build job: "core/release/${ BRANCH_NAME }", parameters: [
+          booleanParam(name: "VALIDATION_ENABLED", value: false),
+          string(name: "RELEASE_PROFILE", value: "weekly")
+        ]
+      }
+    }
+
+    stage("Package"){
+      steps {
+        build job: "core/package/${ BRANCH_NAME }", parameters: [
+          booleanParam(name: "VALIDATION_ENABLED", value: false),
+          string(name: "RELEASE_PROFILE", value: "weekly"),
+          string(name: "JENKINS_VERSION", value: "latest")
+        ]
       }
     }
   }


### PR DESCRIPTION
Reverts jenkins-infra/release#571 now that the security updates are out.