### PR TITLE
Init stable 2.462 LTS

### DIFF
--- a/profile.d/stable
+++ b/profile.d/stable
@@ -15,4 +15,4 @@ SIGN_ALIAS=jenkins
 
 # Used by jenkinsci/packaging
 RELEASELINE=-stable
-JENKINS_VERSION=2.462.2
+JENKINS_VERSION=2.462.3


### PR DESCRIPTION
Modified the `JENKINS_VERSION` value in the environment file (`profile.d/stable`) to match the release.