### PR TITLE
chore: init 2.479.2 lts

### DIFF
--- a/profile.d/stable
+++ b/profile.d/stable
@@ -15,4 +15,4 @@ SIGN_ALIAS=jenkins
 
 # Used by jenkinsci/packaging
 RELEASELINE=-stable
-JENKINS_VERSION=2.479.1
+JENKINS_VERSION=2.479.2


### PR DESCRIPTION
### Description

To update `JENKINS_VERSION` value in `profile.d/stable` to init 2.479.2 LTS. 