### PR TITLE
Disable weekly build for end of year break

### DIFF
--- a/Jenkinsfile.d/core/weekly
+++ b/Jenkinsfile.d/core/weekly
@@ -13,20 +13,7 @@ pipeline {
   stages {
     stage("Release"){
       steps {
-        build job: "core/release/${ BRANCH_NAME }", parameters: [
-          booleanParam(name: "VALIDATION_ENABLED", value: false),
-          string(name: "RELEASE_PROFILE", value: "weekly")
-        ]
-      }
-    }
-
-    stage("Package"){
-      steps {
-        build job: "core/package/${ BRANCH_NAME }", parameters: [
-          booleanParam(name: "VALIDATION_ENABLED", value: false),
-          string(name: "RELEASE_PROFILE", value: "weekly"),
-          string(name: "JENKINS_VERSION", value: "latest")
-        ]
+        echo "Release build is disabled for end of year break"
       }
     }
   }


### PR DESCRIPTION
## Disable weekly build for end of year break

During the end of year break, we won't have Jenkins infrastructure team members generally available.  Rather than risk needing to escalate a broken weekly build to one of them while they are out of office, let's pause weekly builds.

Proposed and discussed in [Jenkins developer mailing list thread](https://groups.google.com/g/jenkinsci-dev/c/YcuXoxF44ko/m/Rp11aa9fAQAJ).

Confirmed in Jenkins infrastructure team meeting 17 Dec 2024.
