### PR TITLE
Schedule special weekly build for Thu 19 Dec 2024

### DIFF
--- a/Jenkinsfile.d/core/weekly
+++ b/Jenkinsfile.d/core/weekly
@@ -5,9 +5,9 @@ pipeline {
     disableConcurrentBuilds()
   }
 
-  // Every Tuesday at 10:30:00 AM Coordinated Universal Time;
+  // Thursday at 9:30:00 AM Coordinated Universal Time - special case for one build;
   triggers {
-    cron '30 10 * * 2'
+    cron '30 9 * * 4'
   }
 
   stages {


### PR DESCRIPTION
## Schedule special weekly build for Thu 19 Dec 2024

Run this build so that we have a Jenkins weekly that can be used in the Jenkins plugin BOM release before the two week break at the end of the year.

Needs approval from @timja before we merge.
