### PR TITLE
Revert "Disable weekly build for end of year break"

### DIFF
--- a/Jenkinsfile.d/core/weekly
+++ b/Jenkinsfile.d/core/weekly
@@ -13,7 +13,20 @@ pipeline {
   stages {
     stage("Release"){
       steps {
-        echo "Release build is disabled for end of year break"
+        build job: "core/release/${ BRANCH_NAME }", parameters: [
+          booleanParam(name: "VALIDATION_ENABLED", value: false),
+          string(name: "RELEASE_PROFILE", value: "weekly")
+        ]
+      }
+    }
+
+    stage("Package"){
+      steps {
+        build job: "core/package/${ BRANCH_NAME }", parameters: [
+          booleanParam(name: "VALIDATION_ENABLED", value: false),
+          string(name: "RELEASE_PROFILE", value: "weekly"),
+          string(name: "JENKINS_VERSION", value: "latest")
+        ]
       }
     }
   }


### PR DESCRIPTION
Reverts jenkins-infra/release#634

Now we've passed the 2 weeks break and we are in 2025, we want to weekly release to happen next Tuesday.