### PR TITLE
chore: init 2.492.2 lts release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode/
 sandbox.env
-.idea
+.idea/
+.DS_Store

--- a/profile.d/stable
+++ b/profile.d/stable
@@ -15,4 +15,4 @@ SIGN_ALIAS=jenkins
 
 # Used by jenkinsci/packaging
 RELEASELINE=-stable
-JENKINS_VERSION=2.492.1
+JENKINS_VERSION=2.492.2


### PR DESCRIPTION
1. Updated `JENKINS_VERSION` to `2.492.2` in profile.d/stable to initiate LTS release
2. Added `.DS_Store` to `.gitignore` for local development environment in macOS