### PR TITLE
chore: init 2.492.3 lts release

### DIFF
--- a/profile.d/stable
+++ b/profile.d/stable
@@ -15,4 +15,4 @@ SIGN_ALIAS=jenkins
 
 # Used by jenkinsci/packaging
 RELEASELINE=-stable
-JENKINS_VERSION=2.492.2
+JENKINS_VERSION=2.492.3


### PR DESCRIPTION
Updated `JENKINS_VERSION` to `2.492.3` in profile.d/stable to initiate LTS release.
