### PR TITLE
Revert 'Disable weekly build'

### DIFF
--- a/Jenkinsfile.d/core/weekly
+++ b/Jenkinsfile.d/core/weekly
@@ -13,7 +13,22 @@ pipeline {
   stages {
     stage("Release"){
       steps {
-        echo "Release build is disabled for security fixes"
+        steps {
+        build job: "core/release/${ BRANCH_NAME }", parameters: [
+          booleanParam(name: "VALIDATION_ENABLED", value: false),
+          string(name: "RELEASE_PROFILE", value: "weekly")
+        ]
+      }
+    }
+
+    stage("Package"){
+      steps {
+        build job: "core/package/${ BRANCH_NAME }", parameters: [
+          booleanParam(name: "VALIDATION_ENABLED", value: false),
+          string(name: "RELEASE_PROFILE", value: "weekly"),
+          string(name: "JENKINS_VERSION", value: "latest")
+        ]
+      }
       }
     }
   }


### PR DESCRIPTION
We're done with the security release, I'm reverting https://github.com/jenkins-infra/release/pull/670