### PR TITLE
Stable 2.504.3

### DIFF
--- a/profile.d/stable
+++ b/profile.d/stable
@@ -15,4 +15,4 @@ SIGN_ALIAS=jenkins
 
 # Used by jenkinsci/packaging
 RELEASELINE=-stable
-JENKINS_VERSION=2.504.2
+JENKINS_VERSION=2.504.3


### PR DESCRIPTION
- **chore(stable): bump Jenkins version to 2.504.3**
