### PR TITLE
feat(PodTemplates): adding service account spec for workload identity usage

### DIFF
--- a/PodTemplates.d/package-linux.yaml
+++ b/PodTemplates.d/package-linux.yaml
@@ -4,10 +4,10 @@ metadata:
   labels:
     jenkins: "agent"
     job: "package"
-    # TODO: track with updatecli from the terraform reports (ref. jenkins-infra/azure#1097 (review))
     #Following label is required by the workload identity process https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview?tabs=dotnet#pod-labels
     azure.workload.identity/use: "true"
 spec:
+  # TODO: track with updatecli from the terraform reports (ref. jenkins-infra/azure#1097 (review))
   serviceAccountName: jenkins-release-agents
   containers:
     - name: jnlp

--- a/PodTemplates.d/package-linux.yaml
+++ b/PodTemplates.d/package-linux.yaml
@@ -5,6 +5,7 @@ metadata:
     jenkins: "agent"
     job: "package"
 spec:
+  serviceAccountName: jenkins-release-agents
   containers:
     - name: jnlp
       image: jenkinsciinfra/packaging:8.0.4

--- a/PodTemplates.d/package-linux.yaml
+++ b/PodTemplates.d/package-linux.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     jenkins: "agent"
     job: "package"
+    # TODO: track with updatecli from the terraform reports (ref. jenkins-infra/azure#1097 (review))
     #Following label is required by the workload identity process https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview?tabs=dotnet#pod-labels
     azure.workload.identity/use: "true"
 spec:

--- a/PodTemplates.d/package-linux.yaml
+++ b/PodTemplates.d/package-linux.yaml
@@ -4,6 +4,8 @@ metadata:
   labels:
     jenkins: "agent"
     job: "package"
+    #Following label is required by the workload identity process https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview?tabs=dotnet#pod-labels
+    azure.workload.identity/use: "true"
 spec:
   serviceAccountName: jenkins-release-agents
   containers:

--- a/PodTemplates.d/package-windows.yaml
+++ b/PodTemplates.d/package-windows.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     jenkins: "slave"
     job: "package"
+    # TODO: track with updatecli from the terraform reports (ref. jenkins-infra/azure#1097 (review))
     #Following label is required by the workload identity process https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview?tabs=dotnet#pod-labels
     azure.workload.identity/use: "true"
     #Following label is required by the NetworkPolicy managed by stable/jenkins helm chart and configured from jenkins-infra/charts

--- a/PodTemplates.d/package-windows.yaml
+++ b/PodTemplates.d/package-windows.yaml
@@ -7,6 +7,7 @@ metadata:
     #Following label is required by the NetworkPolicy managed by stable/jenkins helm chart and configured from jenkins-infra/charts
     jenkins/default-release-jenkins-agent: true
 spec:
+  serviceAccountName: jenkins-release-agents
   containers:
   - image: jenkins/inbound-agent:3309.v27b_9314fd1a_4-7-jdk21-nanoserver-1809
     imagePullPolicy: "IfNotPresent"

--- a/PodTemplates.d/package-windows.yaml
+++ b/PodTemplates.d/package-windows.yaml
@@ -4,12 +4,12 @@ metadata:
   labels:
     jenkins: "slave"
     job: "package"
-    # TODO: track with updatecli from the terraform reports (ref. jenkins-infra/azure#1097 (review))
     #Following label is required by the workload identity process https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview?tabs=dotnet#pod-labels
     azure.workload.identity/use: "true"
     #Following label is required by the NetworkPolicy managed by stable/jenkins helm chart and configured from jenkins-infra/charts
     jenkins/default-release-jenkins-agent: true
 spec:
+  # TODO: track with updatecli from the terraform reports (ref. jenkins-infra/azure#1097 (review))
   serviceAccountName: jenkins-release-agents
   containers:
   - image: jenkins/inbound-agent:3309.v27b_9314fd1a_4-7-jdk21-nanoserver-1809

--- a/PodTemplates.d/package-windows.yaml
+++ b/PodTemplates.d/package-windows.yaml
@@ -4,6 +4,8 @@ metadata:
   labels:
     jenkins: "slave"
     job: "package"
+    #Following label is required by the workload identity process https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview?tabs=dotnet#pod-labels
+    azure.workload.identity/use: "true"
     #Following label is required by the NetworkPolicy managed by stable/jenkins helm chart and configured from jenkins-infra/charts
     jenkins/default-release-jenkins-agent: true
 spec:

--- a/PodTemplates.d/release-linux.yaml
+++ b/PodTemplates.d/release-linux.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     jenkins: "agent"
     job: "release"
+    # TODO: track with updatecli from the terraform reports (ref. jenkins-infra/azure#1097 (review))
     #Following label is required by the workload identity process https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview?tabs=dotnet#pod-labels
     azure.workload.identity/use: "true"
 spec:

--- a/PodTemplates.d/release-linux.yaml
+++ b/PodTemplates.d/release-linux.yaml
@@ -5,6 +5,7 @@ metadata:
     jenkins: "agent"
     job: "release"
 spec:
+  serviceAccountName: jenkins-release-agents
   containers:
     - name: jnlp
       image: jenkinsciinfra/packaging:8.0.4

--- a/PodTemplates.d/release-linux.yaml
+++ b/PodTemplates.d/release-linux.yaml
@@ -4,10 +4,10 @@ metadata:
   labels:
     jenkins: "agent"
     job: "release"
-    # TODO: track with updatecli from the terraform reports (ref. jenkins-infra/azure#1097 (review))
     #Following label is required by the workload identity process https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview?tabs=dotnet#pod-labels
     azure.workload.identity/use: "true"
 spec:
+  # TODO: track with updatecli from the terraform reports (ref. jenkins-infra/azure#1097 (review))
   serviceAccountName: jenkins-release-agents
   containers:
     - name: jnlp

--- a/PodTemplates.d/release-linux.yaml
+++ b/PodTemplates.d/release-linux.yaml
@@ -4,6 +4,8 @@ metadata:
   labels:
     jenkins: "agent"
     job: "release"
+    #Following label is required by the workload identity process https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview?tabs=dotnet#pod-labels
+    azure.workload.identity/use: "true"
 spec:
   serviceAccountName: jenkins-release-agents
   containers:


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4696#issuecomment-3008168249
lets enable workload identity for the MASTER branch pods for now