### PR TITLE
chore(updatecli) track service account for workload identity

### DIFF
--- a/updatecli/updatecli.d/service-account.yaml
+++ b/updatecli/updatecli.d/service-account.yaml
@@ -1,0 +1,56 @@
+name: Bump `serviceAccountName` pod definition
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getServiceAccount:
+    kind: json
+    name: Retrieve Service Account for release.ci agents
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+      key: .release\.ci\.jenkins\.io.agents_kubernetes_clusters.privatek8s_sponsorship.agents_service_account
+
+targets:
+  update-package-linux:
+    name: Update the pad definition for package linux with the new `Service Account`` {{ source "getServiceAccount" }}
+    sourceid: getServiceAccount
+    kind: yaml
+    spec:
+      file: PodTemplates.d/package-linux.yaml
+      key: $.spec.serviceAccountName
+    scmid: default
+  update-package-windows:
+    name: Update the pad definition for package windows with the new `Service Account`` {{ source "getServiceAccount" }}
+    sourceid: getServiceAccount
+    kind: yaml
+    spec:
+      file: PodTemplates.d/package-windows.yaml
+      key: $.spec.serviceAccountName
+    scmid: default
+  update-release-linux:
+    name: Update the pad definition for release linux with the new `Service Account`` {{ source "getServiceAccount" }}
+    sourceid: getServiceAccount
+    kind: yaml
+    spec:
+      file: PodTemplates.d/release-linux.yaml
+      key: $.spec.serviceAccountName
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump `serviceAccountName` in pod definitions to  {{ source "getServiceAccount" }}
+    spec:
+      labels:
+        - dependencies


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4696#issuecomment-3008168249

adding updatecli to track the service account