### PR TITLE
fix(packaging) copy timestamped data to `pkg` and restore partially #738

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -83,7 +83,7 @@ pipeline {
     GPG_FILE                  = 'jenkins-release.gpg'
     GPG_PASSPHRASE            = credentials('release-gpg-passphrase-2023')
     PACKAGING_GIT_REPOSITORY  = 'git@github.com:jenkinsci/packaging.git'
-    PACKAGING_GIT_BRANCH      = 'master'
+    PACKAGING_GIT_BRANCH      = 'remove-ssh-publish/phase-1'
     SIGN_KEYSTORE_FILENAME    = 'jenkins.pfx'
     SIGN_STOREPASS            = credentials('signing-cert-pass-2023')
     WAR_FILENAME              = 'jenkins.war'

--- a/utils/release.bash
+++ b/utils/release.bash
@@ -478,9 +478,28 @@ function showPackagingPlan() {
 }
 
 function syncMirror() {
-	## TODO (short term): rsync data from (??) to /get.jenkins.io/mirrorbits
+	source_dir=/srv/releases/jenkins/
+
+	# Step 1/2: copy binaries from local directory to remote server
+	# TODO: copy to archives.jenkins.io instead of pkg. Requires the same on update center/crawler at the same time.
+	rsync --recursive \
+		--links `# Copy symlinks as symlinks: destination is a Linux filesystem` \
+		--perms `# Preserve permissions: destination is a Linux filesystem` \
+		--devices --specials `# Preserve special files: destination is a Linux filesystem` \
+		--compress `# CPU is cheap, bandwidth is not` \
+		--verbose \
+		--times `# Preserve timestamps` \
+		--exclude=/updates `# populated by https://github.com/jenkins-infra/crawler` \
+		--exclude=/plugins `# populated by https://github.com/jenkins-infra/update-center2` \
+		-e "ssh ${PKGSERVER_SSH_OPTS[*]}" \
+		"${source_dir}" \
+		"${PKGSERVER}":/srv/releases/ `# destination`
+
+	# Step 2/2: trigger remote sync script (generate symlinks, copy to archives and promote staging webdir to production)
+	# TODO: Remove the copy to archive in remote script and generate symlinks here
+	ssh "${PKGSERVER_SSH_OPTS[@]}" "${PKGSERVER}" /srv/releases/sync.sh
+
 	## TODO (long term): trigger a mirrorbits refresh
-	echo NOOP
 }
 
 function main() {


### PR DESCRIPTION
- Partially reverts #738 as I made a mistake thing all copies would be done by jenkinsci/packaging by disabling the `sync.sh` (planning to add the sync to archives.jio here). But it is still needed to generate some symlinks (war, deprecated osx :crazy:, but NOT windows 🤦 )
- Tests https://github.com/jenkinsci/packaging/pull/528
