### PR TITLE
fix(Jenkinsfile.d/release) force recalculation of maven metadata after pushing artifacts

### DIFF
--- a/Jenkinsfile.d/core/release
+++ b/Jenkinsfile.d/core/release
@@ -135,6 +135,13 @@ pipeline {
       steps {
         sh '''
           utils/release.bash --stageRelease
+
+          /**
+          Ensure Artifactory updates the `latest` field in the `jenkins-war` 's `maven-metadata.xml` (sometime it is not updated).
+          Note 1: only useful for weekly releases (no op for LTS)
+          Note 2: Could the "bug" being caused by only using Maven `release:stage` instead of `release:perform`?
+          **/
+          curl -X POST -H 'Content-Length: 0' --fail --user "${MAVEN_REPOSITORY_USERNAME}:${MAVEN_REPOSITORY_PASSWORD}" "https://repo.jenkins-ci.org/api/maven/calculateMetadata/releases/org/jenkins-ci/main/jenkins-war/"
         '''
       }
     }


### PR DESCRIPTION
Sometimes, when a weekly release happens, the file https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/maven-metadata.xml is updated by Artifactory but the field `latest` is not.

It happened multiple times in the past months, last occurrence was for 2.526: 
https://matrix.to/#/!JlkqzpdEnsUUuVtjgE:matrix.org/$yghYNfDqN_8QjcE-WI50I0qJ47jZtgEVyLNEEp0Uk5w?via=gitter.im&via=matrix.org

This PR adds the `curl` request that I usually run as Artifactory administrator to re-compute the `maven-metadata.xml`. This request is executed once and updates the file in 2-3s max.

It avoids the automatic `package` process to build the incorrect (e.g. rebuild previous) version, as it auto-detects the Jenkins version to package using this Artifactory `maven-metadata.xml` file.

Notes:

- As stated in the added comment, we (@smerle33 and I) learned that our Core release process only utilizes the `release:stage` Maven goal and never uses the `release:perform`. Could it be related (as Maven  +Artifactory would believe slightly different between both goals)?
- The "autodetection" from https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/maven-metadata.xml is in fact due to the [`jv` Golang CLI](https://github.com/jenkins-infra/jenkins-version) we maintain and use in this process (to download the WAR from Artifactory and other things). It's also used by `updatecli`, the dependency tracking tool used by the Jenkins Infra.

----

Tested in pair with @smerle33 , we ran it using the credentials from release.ci.jenkins.io used by the pipeline: it worked with success and fixed the XML file.