### PR TITLE
fix: correct comment marker in release pipeline

### DIFF
--- a/Jenkinsfile.d/core/release
+++ b/Jenkinsfile.d/core/release
@@ -136,11 +136,9 @@ pipeline {
         sh '''
           utils/release.bash --stageRelease
 
-          /**
-          Ensure Artifactory updates the `latest` field in the `jenkins-war` 's `maven-metadata.xml` (sometime it is not updated).
-          Note 1: only useful for weekly releases (no op for LTS)
-          Note 2: Could the "bug" being caused by only using Maven `release:stage` instead of `release:perform`?
-          **/
+          # Ensure Artifactory updates the `latest` field in the `jenkins-war` 's `maven-metadata.xml` (sometime it is not updated).
+          # Note 1: only useful for weekly releases (no op for LTS)
+          # Note 2: Could the "bug" being caused by only using Maven `release:stage` instead of `release:perform`?
           curl -X POST -H 'Content-Length: 0' --fail --user "${MAVEN_REPOSITORY_USERNAME}:${MAVEN_REPOSITORY_PASSWORD}" "https://repo.jenkins-ci.org/api/maven/calculateMetadata/releases/org/jenkins-ci/main/jenkins-war/"
         '''
       }


### PR DESCRIPTION
Noticed on 2.529 weekly release job.

Fixup of:
- #755

Ref:
- https://matrix.to/#/!JlkqzpdEnsUUuVtjgE:matrix.org/$nFOKd_YDIZEv1PKKQIIkPNZ-qWOBZU7fNeTG1uD53a8?via=gitter.im&via=matrix.org