### PR TITLE
Make 'list-issue-commits' platform agnostic

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
@@ -46,7 +46,7 @@ Remember to exchange the LTS version, release date and Jira URLs.
 
 - [ ] Update Jira labels for [lts-candidate issues](https://issues.jenkins.io/issues/?filter=12146), either add `2.387.2-fixed` and remove `lts-candidate` or add `2.387.2-rejected`, and retain `lts-candidate`.
 
-- [ ] Backport changes, run the [list-issue-commits script](https://github.com/jenkins-infra/release/blob/master/tools/list-issue-commits) to locate commits via Jira ID, some manual work is required to locate them if the issue ID wasn't present at merge time, backport with `git cherry-pick -x $commit`.
+- [ ] Backport changes, run the [list-issue-commits script](https://github.com/jenkins-infra/release/blob/master/tools/list-issue-commits.sh) to locate commits via Jira ID, some manual work is required to locate them if the issue ID wasn't present at merge time, backport with `git cherry-pick -x $commit`.
 
 - [ ] Open backporting PR with `into-lts` label and summary of changes in description from [lts-candidate-stats script](https://github.com/jenkins-infra/release/blob/master/tools/lts-candidate-stats) and:
   - [ ] the selected [Jira lts-candidates](https://issues.jenkins-ci.org/issues/?filter=12146).

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -183,13 +183,13 @@ Add `2.VVV.p-fixed` and remove `lts-candidate` or add `2.VVV.p-rejected` and ret
 
 ### Backport changes
 
-Run the [list-issue-commits script](https://github.com/jenkins-infra/release/blob/master/tools/list-issue-commits) to locate commits via jira ID and backport them via `cherry-pick -x $commit` into a separate branch based on `stable-2.VVV`.  
+Run the [list-issue-commits script](https://github.com/jenkins-infra/release/blob/master/tools/list-issue-commits.sh) to locate commits via jira ID and backport them via `cherry-pick -x $commit` into a separate branch based on `stable-2.VVV`.  
 Incase there are conflicting commits, pick an [appropriate merge strategy](https://git-scm.com/docs/merge-strategies) to address the conflicts without undoing the change or merging in newer content.
 
 ### Open a backporting PR
 
 Open a PR against the `stable-2.VVV` branch from your separate backporting branch from the prior step.  
-Use the [list-issue-commits script](https://github.com/jenkins-infra/release/blob/master/tools/list-issue-commits) to generate a list of issues to include in the PR description.  
+Use the [list-issue-commits script](https://github.com/jenkins-infra/release/blob/master/tools/list-issue-commits.sh) to generate a list of issues to include in the PR description.  
 Visit the checklist for more information.  
 Additionally, take a look at the [release](https://github.com/jenkins-infra/release/issues?q=is%3Aclosed+label%3Alts-candidate+) and [packaging](https://github.com/jenkinsci/packaging/issues?q=is%3Aclosed+label%3Alts-candidate) repository, for additional LTS candidates.
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -18,7 +18,7 @@ Process through [LTS Candidates](https://issues.jenkins.io/issues/?filter=12146)
 
 #### Identify issue commits
 
-`list-issue-commits <jira_id>` can be used to identify what (properly labeled) commits are
+`./list-issue-commits.sh <jira_id>` can be used to identify what (properly labeled) commits are
 
 - Common for master branch and current branch (no need to backport)
 - On master branch only (needs to be backported). The script reports the number of weekly releases the commit is part of in parentheses.

--- a/tools/list-issue-commits.sh
+++ b/tools/list-issue-commits.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # List commits that belong to particular issue, not yet reported to current branch.
 # In the output, each commit has a number of weekly releases it has been released in
@@ -15,7 +15,7 @@ if [ "$?" -ne 0 ]; then
 fi
 current=$(git log --oneline --grep "$1")
 
-today=$(date --iso-8601)
+today=$(date +"%Y-%m-%d")
 
 identical=()
 patch_commits=()
@@ -35,22 +35,27 @@ while read m; do
     # Not found in current branch
     sha=$(cut -f1 -d' ' <<< "$m")
     patch_commits+=($sha)
-    # Remove trailing ~\d: http://git.vger.kernel.narkive.com/O33undVc/git-describe-contains-abbrev-0-sha1-doesn-t-work-as-expected
+    # Remove trailing ~\d: https://git.vger.kernel.narkive.com/O33undVc/describe-contains-abbrev-0-sha1-doesn-t-work-as-expected
     first_release=$(git describe --contains --abbrev=0 "$sha" 2>/dev/null | sed 's/~.*//')
     if [ "$first_release" != "" ]; then
         release_date=$(git log -1 --format=%ci "$first_release" | sed 's/ .*//')
-        age="$(( ($(/usr/bin/date -d "$today" +%s) - $(/usr/bin/date -d "$release_date" +%s)) / 86400))"
+        today_epoch=$(date -j -f "%Y-%m-%d" "$today" "+%s" 2>/dev/null || date -d "$today" "+%s")
+        release_epoch=$(date -j -f "%Y-%m-%d" "$release_date" "+%s" 2>/dev/null || date -d "$release_date" "+%s")
+        age=$(( (today_epoch - release_epoch) / 86400 ))
         info="$first_release ($age days)"
     else
         info="Unreleased"
     fi
-    echo "$info $m" | grep --color=auto "$1\|" # Grep again to color the output but never hide a line
+    echo "$info $m" | grep --color=auto "$1" # Grep again to color the output but never hide a line
 done <<< "$master"
 
-echo "all: ${patch_commits[@]}"
+if [ ${#patch_commits[@]} -gt 0 ]; then
+    echo "Unique commits on master branch: ${patch_commits[@]}"
+fi
 
 num_matches=${#identical[@]}
-echo "Identical commits: $num_matches"
+branch=$(git rev-parse --abbrev-ref HEAD)
+echo "Commits present on master and $branch branch: $num_matches"
 if [ $num_matches -gt 0 ]; then
     echo "${identical[@]}"
 fi


### PR DESCRIPTION
Fixes https://github.com/jenkins-infra/release/issues/409

Recalculating via epoch makes it work without using `date`, given it's a bit weird on macOS, and I would rather not start messing with `gdate`.

Additionally, I've changed the wording, as I found it a bit difficult to match the task of the script. The output on my macOS is as follows (the Jira issue is present on multiple commits on the master branch, bad merge?): The commit is visible on the master branch only.
```
./a.sh JENKINS-73161
jenkins-2.530 (0 days) 349d4fc407 [JENKINS-73161] Ensure file parameters are retained across Jenkins restarts (#11081)
jenkins-2.530 (0 days) d01cedafa3 [JENKINS-73161] Ensure file parameters are retained across Jenkins restarts
Unique commits on master branch: 349d4fc407 d01cedafa3
Commits present on master and stable-2.528 branch: 0
```