### PR TITLE
Clear the changelist in a spotless compatible format

### DIFF
--- a/utils/release.bash
+++ b/utils/release.bash
@@ -335,12 +335,18 @@ function packaging() {
 	make "$@"
 }
 
+function prepareChangelist() {
+	# Clear the changelist in a format acceptable to spotless
+	sed -i'' -e 's,<changelist>.*</changelist>,<changelist />,g' pom.xml
+}
+
 function prepareRelease() {
 	requireGPGPassphrase
 	requireKeystorePass
 	generateSettingsXml
 
 	printf '\n Prepare Jenkins Release\n\n'
+	prepareChangelist
 	mvn -B -V -s settings-release.xml -ntp release:prepare
 }
 


### PR DESCRIPTION
## Clear the changelist in a spotless compatible format

The `mvn release:prepare` creates an empty changelist entry in the pom.xml file with the format:

`<changelist>.*</changelist>`

Spotless does not like that format and fails the build.

Switch to a format that spotless accepts
