### PR TITLE
Use Maven release plugin 3.1.1

### DIFF
--- a/utils/release.bash
+++ b/utils/release.bash
@@ -20,7 +20,7 @@ function requireAzureKeyvaultCredentials() {
 }
 
 function clean() {
-	mvn -B -V -s settings-release.xml -ntp release:clean
+	mvn -Dmaven-release-plugin.version=3.1.1 -B -V -s settings-release.xml -ntp release:clean
 }
 
 function cloneReleaseGitRepository() {
@@ -341,7 +341,7 @@ function prepareRelease() {
 	generateSettingsXml
 
 	printf '\n Prepare Jenkins Release\n\n'
-	mvn -B -V -s settings-release.xml -ntp release:prepare
+	mvn -Dmaven-release-plugin.version=3.1.1 -B -V -s settings-release.xml -ntp release:prepare
 }
 
 function promoteStagingMavenArtifacts() {
@@ -402,7 +402,7 @@ function stageRelease() {
 	requireKeystorePass
 
 	printf '\n Stage Jenkins Release\n\n'
-	mvn -B -V \
+	mvn -Dmaven-release-plugin.version=3.1.1 -B -V \
 		"-DstagingRepository=${MAVEN_REPOSITORY_NAME}::${MAVEN_REPOSITORY_URL}/${MAVEN_REPOSITORY_NAME}" \
 		-s settings-release.xml \
 		-ntp \
@@ -414,7 +414,7 @@ function performRelease() {
 	requireKeystorePass
 
 	printf '\n Perform Jenkins Release\n\n'
-	mvn -B -V -s settings-release.xml -ntp release:perform
+	mvn -Dmaven-release-plugin.version=3.1.1 -B -V -s settings-release.xml -ntp release:perform
 }
 
 function validateKeystore() {


### PR DESCRIPTION
## Use Maven release plugin 3.1.1

Maven release plugin 3.2.0 (included in parent pom 1.142) seems to ignore our spotless.check.skip definition.  It is checking the spotless formatting and fails that check when `mvn release:prepare` creates the empty changelist tag in a format that is not the format accepted by spotless.
