### PR TITLE
Revert "Use Maven release plugin 3.1.1"

### DIFF
--- a/utils/release.bash
+++ b/utils/release.bash
@@ -20,7 +20,7 @@ function requireAzureKeyvaultCredentials() {
 }
 
 function clean() {
-	mvn -Dmaven-release-plugin.version=3.1.1 -B -V -s settings-release.xml -ntp release:clean
+	mvn -B -V -s settings-release.xml -ntp release:clean
 }
 
 function cloneReleaseGitRepository() {
@@ -341,7 +341,7 @@ function prepareRelease() {
 	generateSettingsXml
 
 	printf '\n Prepare Jenkins Release\n\n'
-	mvn -Dmaven-release-plugin.version=3.1.1 -B -V -s settings-release.xml -ntp release:prepare
+	mvn -B -V -s settings-release.xml -ntp release:prepare
 }
 
 function promoteStagingMavenArtifacts() {
@@ -402,7 +402,7 @@ function stageRelease() {
 	requireKeystorePass
 
 	printf '\n Stage Jenkins Release\n\n'
-	mvn -Dmaven-release-plugin.version=3.1.1 -B -V \
+	mvn -B -V \
 		"-DstagingRepository=${MAVEN_REPOSITORY_NAME}::${MAVEN_REPOSITORY_URL}/${MAVEN_REPOSITORY_NAME}" \
 		-s settings-release.xml \
 		-ntp \
@@ -414,7 +414,7 @@ function performRelease() {
 	requireKeystorePass
 
 	printf '\n Perform Jenkins Release\n\n'
-	mvn -Dmaven-release-plugin.version=3.1.1 -B -V -s settings-release.xml -ntp release:perform
+	mvn -B -V -s settings-release.xml -ntp release:perform
 }
 
 function validateKeystore() {


### PR DESCRIPTION
## Revert "Use Maven release plugin 3.1.1"

Use Maven release plugin 3.2.0 as declared in the pom.xml file of Jenkins core.  Don't override the version. Issue fixed by merged core pull request:

* https://github.com/jenkinsci/jenkins/pull/11285

Testing done:

* Confirmed working as part of testing the merged core pull request

This partially reverts commit ca439b604c5346a9b4d725c0e0c365f4d9f7c1ca.
