### PR TITLE
Use 'cat' instead of gh pager for lts stats

### DIFF
--- a/tools/lts-candidate-stats.sh
+++ b/tools/lts-candidate-stats.sh
@@ -14,6 +14,8 @@ OWNER=jenkinsci
 REPO=jenkins
 SEARCH_LIMIT=100
 
+export GH_PAGER=cat
+
 targetVersion=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout --batch-mode)
 if [[ "$targetVersion" != *"$version"* ]]; then
     echo "The previous version does not appear to be released yet: $targetVersion" >&2


### PR DESCRIPTION
A small cosmetic enhancement piping the output of the lts candidate script to stdout, rather than using the gh pager:

Before:
<img width="136" height="539" alt="Screenshot 2025-11-30 at 19 54 52" src="https://github.com/user-attachments/assets/d65d9d0f-11a5-4fa6-9e94-fa883c0cff42" />
... and so on, requiring interaction.


After:

<img width="637" height="180" alt="Screenshot 2025-11-30 at 19 54 21" src="https://github.com/user-attachments/assets/5ca72dac-0cf2-47e4-b3e7-3713af4c89c6" />
Printing all issues - if any - directly to your shell.