### PR TITLE
feat(packaging) support concurrent staging per branch and allow to disable staging or promoting

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -62,6 +62,21 @@ pipeline {
       description: 'Enable Windows Packaging',
       name: 'WINDOWS_PACKAGING_ENABLED'
     )
+    booleanParam(
+      defaultValue: false,
+      description: 'Force bootstrap (cleanup + initialization from production) of the packages staging environment if data from previous staged build is present.',
+      name: 'FORCE_STAGING_BOOTSTRAP_PARAM'
+    )
+    booleanParam(
+      defaultValue: false,
+      description: 'Select this checkbox if you want to disable promotion to production (e.g. only publish to staging).',
+      name: 'ONLY_STAGING_PARAM'
+    )
+    booleanParam(
+      defaultValue: false,
+      description: 'Select this checkbox if you only want to promote staging to production (e.g. no package generation, only publication).',
+      name: 'ONLY_PROMOTION_PARAM'
+    )
   }
 
   options {
@@ -95,6 +110,13 @@ pipeline {
     WORKING_DIRECTORY         = "release"
     PKCS12_FILE               = "$WORKSPACE/$WORKING_DIRECTORY/jenkins.pfx" // Created by SIGN_KEYSTORE
     PKCS12_PASSWORD_FILE      = credentials('signing-cert-pass-2023')
+    // Sanitize URL to avoid nested subdomains and other URL bad surprises: "feat/foo-stable:2.539" => "feat_foo-stable_2_539"
+    BASE_BIN_DIR              = "${env.GET_JENKINS_IO_STAGING}/${env.BRANCH_NAME.replaceAll('\\.', '_').replaceAll('\\/', '_').replaceAll('\\:', '_')}"
+    // Sanitize URL to avoid nested subdomains and other URL bad surprises: "feat/foo-stable:2.539" => "feat_foo-stable_2_539"
+    BASE_PKG_DIR              = "${env.PKG_JENKINS_IO_STAGING}/${env.BRANCH_NAME.replaceAll('\\.', '_').replaceAll('\\/', '_').replaceAll('\\:', '_')}"
+    FORCE_STAGING_BOOTSTRAP   = "${params.containsKey("FORCE_STAGING_BOOTSTRAP_PARAM") ? params.FORCE_STAGING_BOOTSTRAP_PARAM : false}"
+    ONLY_STAGING              = "${params.containsKey("ONLY_STAGING_PARAM") ? params.ONLY_STAGING_PARAM : false}"
+    ONLY_PROMOTION            = "${params.containsKey("ONLY_PROMOTION_PARAM") ? params.ONLY_PROMOTION_PARAM : false}"
   }
 
   stages {
@@ -118,145 +140,196 @@ pipeline {
       }
 
     }
-    stage('Get GPG key') {
-      steps {
-        checkout scm
-        dir (WORKING_DIRECTORY) {
-          git branch: PACKAGING_GIT_BRANCH, credentialsId: 'release-key', url: PACKAGING_GIT_REPOSITORY
-        }
-
-        sh '''
-          ./utils/release.bash --getGPGKeyFromAzure
-        '''
-
-        dir (WORKING_DIRECTORY) {
-          stash includes: GPG_FILE , name: 'GPG'
-        }
-
-        sh './utils/release.bash --configureGPG'
+    stage('Publish to staging') {
+      when {
+        environment name: 'ONLY_PROMOTION', value: 'false'
       }
-    }
+      stages {
+        stage('Get GPG key') {
+          steps {
+            checkout scm
+            dir (WORKING_DIRECTORY) {
+              git branch: PACKAGING_GIT_BRANCH, credentialsId: 'release-key', url: PACKAGING_GIT_REPOSITORY
+            }
 
-    stage('Get Code Signing Certificate') {
-      steps {
-        sh '''
-          utils/release.bash --downloadAzureKeyvaultSecret
-          utils/release.bash --configureKeystore
-        '''
+            sh '''
+              ./utils/release.bash --getGPGKeyFromAzure
+            '''
 
-        stash includes: SIGN_KEYSTORE_FILENAME, name: 'KEYSTORE'
-      }
-    }
+            dir (WORKING_DIRECTORY) {
+              stash includes: GPG_FILE , name: 'GPG'
+            }
 
-    stage('Download WAR archive to package') {
-      steps{
-        sh '''
-          ./utils/release.bash --downloadJenkins
-        '''
-        dir (WORKING_DIRECTORY) {
-          stash includes: WAR_FILENAME, name: "WAR"
-          archiveArtifacts artifacts: "*.war"
+            sh './utils/release.bash --configureGPG'
+          }
         }
-      }
-    }
-    stage('Package') {
-      failFast false
-      parallel {
-        stage('WAR') {
-          stages {
-            stage('Publish') {
-              steps {
-                sh '''
-                  ./utils/release.bash --packaging war.publish
-                '''
-              }
+        stage('Get Code Signing Certificate') {
+          steps {
+            sh '''
+              utils/release.bash --downloadAzureKeyvaultSecret
+              utils/release.bash --configureKeystore
+            '''
+
+            stash includes: SIGN_KEYSTORE_FILENAME, name: 'KEYSTORE'
+          }
+        }
+        stage('Prepare package staging environment') {
+          steps {
+            sh '''
+              # Bootstrap (e.g. reset to production) all stagings for this branch if requested by the user or if missing a directory
+              if [ "${FORCE_STAGING_BOOTSTRAP}" = "true" ] || [ ! -d "${BASE_BIN_DIR}" ] || [ ! -d "${BASE_PKG_DIR}" ]
+              then
+                echo "Bootstrap (reset to production) of the staging environment for ${BASE_BIN_DIR} and ${BASE_PKG_DIR} directories..."
+                rm -rf "${BASE_BIN_DIR}" "${BASE_PKG_DIR}"
+                mkdir -p "${BASE_BIN_DIR}" "${BASE_PKG_DIR}"
+
+                # TODO: Initialize from production with symlinks?
+                # Initialize from production only for RPMs to get the history when rebuilding index (debian don't care)
+                rsync -avtz --chown=1000:1000 "${GET_JENKINS_IO_PRODUCTION}/rpm" "${BASE_BIN_DIR}/"
+
+                # Initialize from production as we need an initial package state. We don't sync old package index which are kept in production.
+                rsync -avtz --chown=1000:1000 --exclude="*-legacy/*" "${PKG_JENKINS_IO_PRODUCTION}/" "${BASE_PKG_DIR}/"
+              fi
+            '''
+          }
+        }
+        stage('Download WAR archive to package') {
+          steps {
+            sh '''
+              ./utils/release.bash --downloadJenkins
+            '''
+            dir (WORKING_DIRECTORY) {
+              stash includes: WAR_FILENAME, name: "WAR"
+              archiveArtifacts artifacts: "*.war"
             }
           }
         }
-        stage('Debian') {
-          stages {
-            stage('Build') {
-              steps {
-                sh '''
-                  ./utils/release.bash --packaging deb
-                '''
-                dir (WORKING_DIRECTORY) {
-                  archiveArtifacts artifacts: "target/debian/*.deb"
-                }
-              }
-            }
-            stage('Publish') {
-              steps {
-                sh '''
-                  ./utils/release.bash --packaging deb.publish
-                '''
-              }
-            }
-          }
-        }
-        stage('RPM') {
-          stages {
-            stage('Build'){
-              steps {
-                sh '''
-                  ./utils/release.bash --packaging rpm
-                '''
-                dir (WORKING_DIRECTORY){
-                  archiveArtifacts artifacts: "target/rpm/*.rpm"
-                }
-              }
-            }
-            stage('Publish'){
-              steps {
-                sh '''
-                  ./utils/release.bash --packaging rpm.publish
-                '''
-              }
-            }
-          }
-        }
-        stage('Windows') {
-          when {
-            environment name: 'WINDOWS_PACKAGING_ENABLED', value: 'true'
-          }
-          stages {
-            stage('Build') {
-              // Windows requirement: Every steps need to be executed inside default jnlp
-              // as the step 'container' is known to not be working
-              agent {
-                kubernetes {
-                  yamlFile 'PodTemplates.d/package-windows.yaml'
-                }
-              }
-              steps {
-                container('dotnet') {
-                  checkout scm
-                  dir (WORKING_DIRECTORY) {
-                    git branch: PACKAGING_GIT_BRANCH, credentialsId: 'release-key', url: PACKAGING_GIT_REPOSITORY
-
-                    unstash 'GPG'
-                    unstash 'WAR'
-                    unstash 'KEYSTORE'
-
-                    powershell '''
-                      Get-ChildItem env:
-                      $env:WAR=(Resolve-Path .\\jenkins.war).Path
-                      & .\\make.ps1
+        stage('Package') {
+          failFast false
+          parallel {
+            stage('WAR') {
+              stages {
+                stage('Publish') {
+                  steps {
+                    sh '''
+                      ./utils/release.bash --packaging war.publish
                     '''
-                    // Don't archive the full path
-                    dir('msi\\build\\bin\\Release\\en-US') {
-                      archiveArtifacts '*.msi*'
-                    }
-
                   }
                 }
               }
             }
-            stage('Publish') {
+            stage('Debian') {
+              stages {
+                stage('Build') {
+                  steps {
+                    sh '''
+                      ./utils/release.bash --packaging deb
+                    '''
+                    dir (WORKING_DIRECTORY) {
+                      archiveArtifacts artifacts: "target/debian/*.deb"
+                    }
+                  }
+                }
+                stage('Publish') {
+                  steps {
+                    sh '''
+                      ./utils/release.bash --packaging deb.publish
+                    '''
+                  }
+                }
+              }
+            }
+            stage('RPM') {
+              stages {
+                stage('Build'){
+                  steps {
+                    sh '''
+                      ./utils/release.bash --packaging rpm
+                    '''
+                    dir (WORKING_DIRECTORY){
+                      archiveArtifacts artifacts: "target/rpm/*.rpm"
+                    }
+                  }
+                }
+                stage('Publish'){
+                  steps {
+                    sh '''
+                      ./utils/release.bash --packaging rpm.publish
+                    '''
+                  }
+                }
+              }
+            }
+            stage('Windows') {
+              when {
+                environment name: 'WINDOWS_PACKAGING_ENABLED', value: 'true'
+              }
+              stages {
+                stage('Build') {
+                  // Windows requirement: Every steps need to be executed inside default jnlp
+                  // as the step 'container' is known to not be working
+                  agent {
+                    kubernetes {
+                      yamlFile 'PodTemplates.d/package-windows.yaml'
+                    }
+                  }
+                  steps {
+                    container('dotnet') {
+                      checkout scm
+                      dir (WORKING_DIRECTORY) {
+                        git branch: PACKAGING_GIT_BRANCH, credentialsId: 'release-key', url: PACKAGING_GIT_REPOSITORY
+
+                        unstash 'GPG'
+                        unstash 'WAR'
+                        unstash 'KEYSTORE'
+
+                        powershell '''
+                          Get-ChildItem env:
+                          $env:WAR=(Resolve-Path .\\jenkins.war).Path
+                          & .\\make.ps1
+                        '''
+                        // Don't archive the full path
+                        dir('msi\\build\\bin\\Release\\en-US') {
+                          archiveArtifacts '*.msi*'
+                        }
+
+                      }
+                    }
+                  }
+                }
+                stage('Publish') {
+                  steps {
+                    unarchive mapping: ['*.msi*': WORKING_DIRECTORY]
+                    sh '''
+                      ./utils/release.bash --packaging msi.publish
+                    '''
+                  }
+                }
+              }
+            }
+          }
+        }
+        stage('Promote') {
+          failFast true
+          parallel {
+            stage('Maven Repository') {
+              when {
+                environment name: 'MAVEN_STAGING_REPOSITORY_PROMOTION_ENABLED', value: 'true'
+              }
+
               steps {
-                unarchive mapping: ['*.msi*': WORKING_DIRECTORY]
                 sh '''
-                  ./utils/release.bash --packaging msi.publish
+                  ./utils/release.bash --promoteStagingMavenArtifacts
+                '''
+              }
+            }
+            stage('Git Repository') {
+              when {
+                environment name: 'GIT_STAGING_REPOSITORY_PROMOTION_ENABLED', value: 'true'
+              }
+              steps {
+                sh '''
+                  ./utils/release.bash --promoteStagingGitRepository
                 '''
               }
             }
@@ -264,39 +337,15 @@ pipeline {
         }
       }
     }
-    stage('Promote') {
-      failFast true
-      parallel {
-        stage('Maven Repository') {
-          when {
-            environment name: 'MAVEN_STAGING_REPOSITORY_PROMOTION_ENABLED', value: 'true'
-          }
-
-          steps {
-            sh '''
-              ./utils/release.bash --promoteStagingMavenArtifacts
-            '''
-          }
-        }
-        stage('Git Repository') {
-          when {
-            environment name: 'GIT_STAGING_REPOSITORY_PROMOTION_ENABLED', value: 'true'
-          }
-          steps {
-            sh '''
-              ./utils/release.bash --promoteStagingGitRepository
-            '''
-          }
-        }
-      }
-    }
-    // Force mirror synchronization
     stage('Promote Packages and sync mirrors') {
+      when {
+        environment name: 'ONLY_STAGING', value: 'false'
+      }
       environment {
         SSH_HOSTKEY_ARCHIVES_JENKINS_IO   = credentials('ssh-hostkey-archives.jenkins.io')
         SSH_HOSTKEY_PKG_ORIGIN_JENKINS_IO = credentials('ssh-hostkey-pkg.origin.jenkins.io')
       }
-      steps{
+      steps {
         sshagent(credentials: [
           'pkgserver',
           'archives.jenkins.io',
@@ -312,11 +361,14 @@ pipeline {
       }
     }
     stage('Invalidate Fastly Cache') {
+      when {
+        environment name: 'ONLY_STAGING', value: 'false'
+      }
       environment {
         FASTLY_API_TOKEN = credentials('fastly-api-token')
         FASTLY_SERVICE_ID = credentials('fastly_pkgserver_service_id')
       }
-      steps{
+      steps {
         sh '''
           ./utils/release.bash --invalidateFastlyCache
         '''

--- a/PodTemplates.d/package-linux.yaml
+++ b/PodTemplates.d/package-linux.yaml
@@ -17,6 +17,14 @@ spec:
           value: "/opt/jdk-21/bin/java"
         - name: "JENKINS_JAVA_OPTS"
           value: "-XX:+PrintCommandLineFlags"
+        - name: "GET_JENKINS_IO_STAGING"
+          value: "/var/www/get.jenkins.io.staging"
+        - name: "PKG_JENKINS_IO_STAGING"
+          value: "/var/www/pkg.jenkins.io.staging"
+        - name: "GET_JENKINS_IO_PRODUCTION"
+          value: "/var/www/get.jenkins.io.production"
+        - name: "PKG_JENKINS_IO_PRODUCTION"
+          value: "/var/www/pkg.jenkins.io.production"
       resources:
         limits:
           memory: "1Gi"

--- a/env/package.mk
+++ b/env/package.mk
@@ -3,14 +3,12 @@
 #
 
 # where to put binary files
-export BASE_BIN_DIR=/var/www/get.jenkins.io.staging
 export WARDIR=${BASE_BIN_DIR}/war${RELEASELINE}
 export MSIDIR=${BASE_BIN_DIR}/windows${RELEASELINE}
 export DEBDIR=${BASE_BIN_DIR}/debian${RELEASELINE}
 export RPMDIR=${BASE_BIN_DIR}/rpm${RELEASELINE}
 
 # where to put repository index and other web contents
-export BASE_PKG_DIR=/var/www/pkg.jenkins.io.staging
 export RPM_WEBDIR=${BASE_PKG_DIR}/rpm${RELEASELINE}
 export MSI_WEBDIR=${BASE_PKG_DIR}/windows${RELEASELINE}
 export DEB_WEBDIR=${BASE_PKG_DIR}/debian${RELEASELINE}


### PR DESCRIPTION
Ref. https://github.com/jenkinsci/packaging/issues/221#issuecomment-3598121559

Also requires https://github.com/jenkins-infra/kubernetes-management/pull/7286

- Publish to staging into distinct directories to allow concurrent stagings
- Introduce a new pipeline parameter `FORCE_STAGING_BOOTSTRAP_PARAM` to allow resetting the staging websites to production
- Introduce a new pipeline parameter `ONLY_STAGING_PARAM` to allow disabling promotion (to prepare a release for testing only or some times before promotion to production)
- Introduce a new pipeline parameter `ONLY_PROMOTION` to allow disabling staging (to only promote staged packages to production)
- Improve the output of the initial "Plan" stage to include staging/promotion details
- chore: pass staging/production absolute path from within the pod template to avoid settings duplication

----

Validations performed:

- Ensured that the packaging pipeline fails immediately with both `ONLY_STAGING_PARAM` and `ONLY_PROMOTION` selected: https://release.ci.jenkins.io/job/core/job/package/job/feat%252Fstaging-per-branch/25/
  ```
  ERROR: you can't disable both staging (ONLY_PROMOTION=true) and promotion (ONLY_STAGING=true).
  ```
- Ensured that the packaging pipeline fails immediately with both `FORCE_STAGING_BOOTSTRAP_PARAM` and `ONLY_PROMOTION` selected: https://release.ci.jenkins.io/job/core/job/package/job/feat%252Fstaging-per-branch/26/
  ```
  ERROR: you can't disable staging (ONLY_PROMOTION=true) while forcing for a staging bootstrap (FORCE_STAGING_BOOTSTRAP=true).
  ```
- Ran a pipeline with only staging enabled (https://release.ci.jenkins.io/job/core/job/package/job/feat%252Fstaging-per-branch/27/) with success and checked the resulting website (https://feat_staging-per-branch.staging.pkg.origin.jenkins.io and https://staging.get.jenkins.io/feat_staging-per-branch) with Docker containers for the Debian (with Debian Buster) and RPM (with Opensuse leap) repositories can be added and allow installing the generated packages from staging only (easy to test: each step - index update and package download- fails with TCP error when stopping my VPN)

  ```
  19:36:48  New Jenkins core packages for version 2.539 (weekly release)
  19:36:48  
  19:36:48  Those new packages will be generated based on a war file downloaded
  19:36:48  from https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/
  19:36:48  Once built, packages will be published to staging (at https://feat_staging-per-branch.staging.pkg.origin.jenkins.io and https://staging.get.jenkins.io/feat_staging-per-branch).
  19:36:48  Git Repository promotion is disabled
  19:36:48  Maven repository promotion is disabled
  ```
- Ran a pipeline with defaults and the [debug commit which set promotion to dry run](https://github.com/jenkins-infra/release/pull/799/commits/5d0f789c5d51111c892e1ea69df0b4b7df6029bd) (https://release.ci.jenkins.io/job/core/job/package/job/feat%252Fstaging-per-branch/29/pipeline-overview/?selected-node=207) with success and checked both the output of the dry run and the resulting website (https://feat_staging-per-branch.staging.pkg.origin.jenkins.io and https://staging.get.jenkins.io/feat_staging-per-branch) with Docker containers for the Debian (with Debian Buster) and RPM (with Opensuse leap) repositories can be added and allow installing the generated packages from staging only (easy to test: each step - index update and package download- fails with TCP error when stopping my VPN)

  ```
  19:36:48  New Jenkins core packages for version 2.539 (weekly release)
  19:36:48  
  19:36:48  Those new packages will be generated based on a war file downloaded
  19:36:48  from https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/
  19:36:48  Once built, packages will be published to staging (at https://feat_staging-per-branch.staging.pkg.origin.jenkins.io and https://staging.get.jenkins.io/feat_staging-per-branch).
  19:36:48  Git Repository promotion is disabled
  19:36:48  Maven repository promotion is disabled
  ```
- Ran a pipeline with "staging only" and "force bootstrap" (- Same with a reset before: https://release.ci.jenkins.io/job/core/job/package/job/feat%252Fstaging-per-branch/30/) and check that files and metadatas are being updated
- Ran a pipeline with "promotion only" and the [debug commit which set promotion to dry run](https://github.com/jenkins-infra/release/pull/799/commits/5d0f789c5d51111c892e1ea69df0b4b7df6029bd) (https://release.ci.jenkins.io/job/core/job/package/job/feat%252Fstaging-per-branch/29/pipeline-overview/?selected-node=207), and check the output of the dry run rsyncs

----

Important: the commit https://github.com/jenkins-infra/release/pull/799/commits/5d0f789c5d51111c892e1ea69df0b4b7df6029bd will be removed **before** merging