### PR TITLE
test(package) disable temporarily promotion for automated weekly 2.540 package build to allow verifying promotion manually

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -115,7 +115,9 @@ pipeline {
     // Sanitize URL to avoid nested subdomains and other URL bad surprises: "feat/foo-stable:2.539" => "feat_foo-stable_2_539"
     BASE_PKG_DIR              = "${env.PKG_JENKINS_IO_STAGING}/${env.BRANCH_NAME.replaceAll('\\.', '_').replaceAll('\\/', '_').replaceAll('\\:', '_')}"
     FORCE_STAGING_BOOTSTRAP   = "${params.containsKey("FORCE_STAGING_BOOTSTRAP_PARAM") ? params.FORCE_STAGING_BOOTSTRAP_PARAM : false}"
-    ONLY_STAGING              = "${params.containsKey("ONLY_STAGING_PARAM") ? params.ONLY_STAGING_PARAM : false}"
+    // Commented temporarily only for 2.540 to validate promotion
+    // ONLY_STAGING              = "${params.containsKey("ONLY_STAGING_PARAM") ? params.ONLY_STAGING_PARAM : false}"
+    ONLY_STAGING              = "true"
     ONLY_PROMOTION            = "${params.containsKey("ONLY_PROMOTION_PARAM") ? params.ONLY_PROMOTION_PARAM : false}"
   }
 


### PR DESCRIPTION
This PR allows a manual testing of the "promotion" process introduced in #799 .

As explained in the [matrix thread for the weekly release 2.540](https://matrix.to/#/!JlkqzpdEnsUUuVtjgE:matrix.org/$XZuM_pB4lan6hT4EdQXjsGig063CYmWRzUwKljLHScU?via=matrix.org&via=gitter.im):

> The goal is validate the promotion staging -> production by running it manually once. Then I'll disable this behavior once promotion is successful.
> 
> We want to do this on a weekly release where it only delays a bit while allowing us a real life test. Because on LTS/security release we don't want to "discover" if it works or not :D

Once the weekly release 2.540 is validated, we'll have to immediately revert this PR!

----

Validation done:

- Ran a pipeline on this branch once to have the build params parsed
- Ran a second pipeline with same parameters as the usual weekly build (retrieved from the master branch [last week for 2.539](https://release.ci.jenkins.io/job/core/job/package/job/master/439/parameters/)): it has to be successful, generate a staging repository with the branch name, but no promotion
  - https://release.ci.jenkins.io/job/core/job/package/job/test%252Fpackaging%252Fweekly-2.540%252Fstaging-only/2/

<img width="1092" height="393" alt="Capture d’écran 2025-12-02 à 12 19 11" src="https://github.com/user-attachments/assets/4c8c0d71-9b49-49df-be28-95e022923ddd" />
