### PR TITLE
Revert "test(package) disable temporarily promotion for automated weekly 2.540 package build to allow verifying promotion manually"

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -115,9 +115,7 @@ pipeline {
     // Sanitize URL to avoid nested subdomains and other URL bad surprises: "feat/foo-stable:2.539" => "feat_foo-stable_2_539"
     BASE_PKG_DIR              = "${env.PKG_JENKINS_IO_STAGING}/${env.BRANCH_NAME.replaceAll('\\.', '_').replaceAll('\\/', '_').replaceAll('\\:', '_')}"
     FORCE_STAGING_BOOTSTRAP   = "${params.containsKey("FORCE_STAGING_BOOTSTRAP_PARAM") ? params.FORCE_STAGING_BOOTSTRAP_PARAM : false}"
-    // Commented temporarily only for 2.540 to validate promotion
-    // ONLY_STAGING              = "${params.containsKey("ONLY_STAGING_PARAM") ? params.ONLY_STAGING_PARAM : false}"
-    ONLY_STAGING              = "true"
+    ONLY_STAGING              = "${params.containsKey("ONLY_STAGING_PARAM") ? params.ONLY_STAGING_PARAM : false}"
     ONLY_PROMOTION            = "${params.containsKey("ONLY_PROMOTION_PARAM") ? params.ONLY_PROMOTION_PARAM : false}"
   }
 


### PR DESCRIPTION
Reverts jenkins-infra/release#800

The "staging only" process for 2.540 went well (automation failed due to an initial permission issue which has been fixed).
https://release.ci.jenkins.io/job/core/job/package/job/master/442/ was successful.


This PR is required to allow a successful promotion of packages for 2.540.