### PR TITLE
feat(windows): replace Windows 2019 by 2022 in the `jnlp` pod and node pool of packaging pod template

### DIFF
--- a/PodTemplates.d/package-windows.yaml
+++ b/PodTemplates.d/package-windows.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   serviceAccountName: release-ci-jenkins-io-agents
   containers:
-  - image: jenkins/inbound-agent:3355.v388858a_47b_33-3-jdk21-nanoserver-2022
+  - image: jenkins/inbound-agent:3355.v388858a_47b_33-3-jdk21-nanoserver-ltsc2022
     imagePullPolicy: "IfNotPresent"
     name: "jnlp"
     env:


### PR DESCRIPTION
This PR switches the Windows packing pod template from `w2019` to `w2022` as we can't have Windows 20219 node pool on AKS 1.33 clusters anymore.

It specifies the Windows version to use for dotnet/framework image, and use a `nanoserver-ltsc2022` agent instead of a `nanoserver-1809` one.

It also adds a toleration on (Windows) `version`.

Refs:
- https://github.com/jenkins-infra/azure/pull/1270
- https://github.com/jenkins-infra/azure/pull/1267#issuecomment-3641354439
- https://github.com/jenkins-infra/helpdesk/issues/4820
- https://github.com/jenkins-infra/helpdesk/issues/4791