### PR TITLE
feat(stable-2.528/windows): replace Windows 2019 by 2022 in the `jnlp` pod and node pool of packaging pod template

### DIFF
--- a/PodTemplates.d/package-windows.yaml
+++ b/PodTemplates.d/package-windows.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   serviceAccountName: release-ci-jenkins-io-agents
   containers:
-  - image: jenkins/inbound-agent:3341.v0766d82b_dec0-4-jdk21-nanoserver-1809
+  - image: jenkins/inbound-agent:3341.v0766d82b_dec0-4-jdk21-nanoserver-ltsc2022
     imagePullPolicy: "IfNotPresent"
     name: "jnlp"
     env:
@@ -31,7 +31,7 @@ spec:
       - Start-Sleep -s 2147483 # We must be sure that the process used by the container doesn't stop before the Jenkins job and second is not greater than 2147483
     command:
       - "powershell.exe"
-    image: "mcr.microsoft.com/dotnet/framework/sdk:3.5"
+    image: "mcr.microsoft.com/dotnet/framework/sdk:3.5-windowsservercore-ltsc2022"
     imagePullPolicy: "IfNotPresent"
     name: "dotnet"
     resources:
@@ -45,12 +45,16 @@ spec:
       privileged: false
     tty: false
   nodeSelector:
-    kubernetes.azure.com/agentpool: w2019
+    kubernetes.azure.com/agentpool: w2022
     kubernetes.io/os: windows
   tolerations:
     - key: "os"
       operator: "Equal"
       value: "windows"
+      effect: "NoSchedule"
+    - key: "version"
+      operator: "Equal"
+      value: "windows2022"
       effect: "NoSchedule"
     - key: "jenkins"
       operator: "Equal"


### PR DESCRIPTION
Backport of #813 in case we need to publish a 2.528.4 before the next LTS planned in January.

This PR switches the Windows packing pod template from `w2019` to `w2022` as we can't have Windows 20219 node pool on AKS 1.33 clusters anymore.

It specifies the Windows version to use for dotnet/framework image, and use a `nanoserver-ltsc2022` agent instead of a `nanoserver-1809` one.

It also adds a toleration on (Windows) `version`.

Refs:
- https://github.com/jenkins-infra/azure/pull/1270
- https://github.com/jenkins-infra/azure/pull/1267#issuecomment-3641354439
- https://github.com/jenkins-infra/helpdesk/issues/4820
- https://github.com/jenkins-infra/helpdesk/issues/4791
- #813 
