### PR TITLE
Start weekly build 6 hours earlier (04:30 AM UTC)

### DIFF
--- a/Jenkinsfile.d/core/weekly
+++ b/Jenkinsfile.d/core/weekly
@@ -5,9 +5,9 @@ pipeline {
     disableConcurrentBuilds()
   }
 
-  // Every Tuesday at 10:30:00 AM Coordinated Universal Time;
+  // Every Tuesday at 4:30:00 AM Coordinated Universal Time;
   triggers {
-    cron '30 10 * * 2'
+    cron '30 4 * * 2'
   }
 
   stages {


### PR DESCRIPTION
## Start weekly build 6 hours earlier (04:30 AM UTC)

Since Jenkins infra team members are available in the India and European time zones, let's start the builds early enough that they can easily complete within the working day.

Discussed in Jenkins developers mailing list at:

* https://groups.google.com/g/jenkinsci-dev/c/wVddkpE4JDU/m/mNhpfpHGCwAJ
