### PR TITLE
fix(package,infra-agent-health) use HTTPS instead of SSH to clone jenkinsci/packaging

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -97,7 +97,8 @@ pipeline {
     AZURE_VAULT_TENANT_ID     = credentials('azure-vault-tenant-id')
     GPG_FILE                  = 'jenkins-release.gpg'
     GPG_PASSPHRASE            = credentials('release-gpg-passphrase-2023')
-    PACKAGING_GIT_REPOSITORY  = 'git@github.com:jenkinsci/packaging.git'
+    // Using HTTPS with no credentials - https://github.com/jenkins-infra/helpdesk/issues/4909 - need a GH app if rate limited or need to write things to git
+    PACKAGING_GIT_REPOSITORY  = 'https://github.com/jenkinsci/packaging.git'
     PACKAGING_GIT_BRANCH      = 'stable-2.528'
     SIGN_KEYSTORE_FILENAME    = 'jenkins.pfx'
     SIGN_STOREPASS            = credentials('signing-cert-pass-2023')
@@ -149,7 +150,7 @@ pipeline {
           steps {
             checkout scm
             dir (WORKING_DIRECTORY) {
-              git branch: PACKAGING_GIT_BRANCH, credentialsId: 'release-key', url: PACKAGING_GIT_REPOSITORY
+              git branch: PACKAGING_GIT_BRANCH, url: PACKAGING_GIT_REPOSITORY
             }
 
             sh '''
@@ -300,7 +301,7 @@ pipeline {
                     container('dotnet') {
                       checkout scm
                       dir (WORKING_DIRECTORY) {
-                        git branch: PACKAGING_GIT_BRANCH, credentialsId: 'release-key', url: PACKAGING_GIT_REPOSITORY
+                        git branch: PACKAGING_GIT_BRANCH, url: PACKAGING_GIT_REPOSITORY
 
                         unstash 'GPG'
                         unstash 'WAR'

--- a/Jenkinsfile.d/infra-agents-health
+++ b/Jenkinsfile.d/infra-agents-health
@@ -15,6 +15,10 @@ pipeline {
     AZURE_VAULT_CLIENT_ID     = credentials('azure-vault-client-id')
     AZURE_VAULT_CLIENT_SECRET = credentials('azure-vault-client-secret')
     AZURE_VAULT_TENANT_ID     = credentials('azure-vault-tenant-id')
+    // Using HTTPS with no credentials - https://github.com/jenkins-infra/helpdesk/issues/4909 - need a GH app if rate limited or need to write things to git
+    PACKAGING_GIT_REPOSITORY  = 'https://github.com/jenkinsci/packaging.git'
+    PACKAGING_GIT_BRANCH      = 'master'
+    WORKING_DIRECTORY         = "release"
   }
 
   stages {
@@ -31,10 +35,13 @@ pipeline {
             SSH_HOSTKEY_PKG_ORIGIN_JENKINS_IO = credentials('ssh-hostkey-pkg.origin.jenkins.io')
           }
           steps {
+            checkout scm
+
             // Ensure we can get the secondary git repository used for packaging
-            dir ('./release'){
-              git branch: 'master', credentialsId: 'release-key', url: 'git@github.com:jenkinsci/packaging.git'
+            dir (WORKING_DIRECTORY) {
+              git branch: PACKAGING_GIT_BRANCH, url: PACKAGING_GIT_REPOSITORY
             }
+
             // Ensure we can retrieve the Code Signing Certificate'
             sh '''
             utils/release.bash --downloadAzureKeyvaultSecret
@@ -94,6 +101,14 @@ pipeline {
             pwsh 'java -version'
             container('dotnet') {
                 powershell 'msbuild -version'
+            }
+
+            container('dotnet') {
+              checkout scm
+              // Ensure we can get the secondary git repository used for packaging
+              dir (WORKING_DIRECTORY) {
+                git branch: PACKAGING_GIT_BRANCH, url: PACKAGING_GIT_REPOSITORY
+              }
             }
           }
         }


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4909

This PR is a backport of #817 in case we need a 2.528.4 LTS release.

(cherry picked from commit e87b28cc588d868013e595dce6d180974e48bb71)