### PR TITLE
fix(package) ensure fastly decache fails fast if the API answers an error

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -348,7 +348,7 @@ pipeline {
         }
       }
     }
-    stage('Invalidate Fastly Cache') {
+    stage('Invalidate Fastly Cache for pkg.jenkins.io') {
       when {
         environment name: 'ONLY_STAGING', value: 'false'
       }

--- a/utils/release.bash
+++ b/utils/release.bash
@@ -291,9 +291,10 @@ function guessGitBranchInformation() {
 
 function invalidateFastlyCache() {
 	: "${FASTLY_API_TOKEN:?Require FASTLY_API_TOKEN env variable}"
+	# Expecting pkg.jenkins.io site ID
 	: "${FASTLY_SERVICE_ID:?Require FASTLY_SERVICE_ID env variable}"
 
-	curl \
+	curl --fail --location \
 		-X POST \
 		-H "Fastly-Key: ${FASTLY_API_TOKEN}" \
 		-H "Accept: application/json" \


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4910#issuecomment-3656776204