### PR TITLE
fix(package/utils) always bootstrap staging from scratch with only RPM packages from before

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -64,11 +64,6 @@ pipeline {
     )
     booleanParam(
       defaultValue: false,
-      description: 'Force bootstrap (cleanup + initialization from production) of the packages staging environment if data from previous staged build is present.',
-      name: 'FORCE_STAGING_BOOTSTRAP_PARAM'
-    )
-    booleanParam(
-      defaultValue: false,
       description: 'Select this checkbox if you want to disable promotion to production (e.g. only publish to staging).',
       name: 'ONLY_STAGING_PARAM'
     )
@@ -115,7 +110,6 @@ pipeline {
     BASE_BIN_DIR              = "${env.GET_JENKINS_IO_STAGING}/${env.BRANCH_NAME.replaceAll('\\.', '_').replaceAll('\\/', '_').replaceAll('\\:', '_')}"
     // Sanitize URL to avoid nested subdomains and other URL bad surprises: "feat/foo-stable:2.539" => "feat_foo-stable_2_539"
     BASE_PKG_DIR              = "${env.PKG_JENKINS_IO_STAGING}/${env.BRANCH_NAME.replaceAll('\\.', '_').replaceAll('\\/', '_').replaceAll('\\:', '_')}"
-    FORCE_STAGING_BOOTSTRAP   = "${params.containsKey("FORCE_STAGING_BOOTSTRAP_PARAM") ? params.FORCE_STAGING_BOOTSTRAP_PARAM : false}"
     ONLY_STAGING              = "${params.containsKey("ONLY_STAGING_PARAM") ? params.ONLY_STAGING_PARAM : false}"
     ONLY_PROMOTION            = "${params.containsKey("ONLY_PROMOTION_PARAM") ? params.ONLY_PROMOTION_PARAM : false}"
   }

--- a/README.adoc
+++ b/README.adoc
@@ -391,7 +391,6 @@ To do that, follow these steps:
 .. `GIT_STAGING_REPOSITORY_PROMOTION_ENABLED` set to false (manually merged by security team)
 .. `VALIDATION_ENABLED` set to true (we want a summary of what need to be done at the beginning)
 .. `WINDOWS_PACKAGING_ENABLED` set to true (we want to generate and stage Windows package along with other packages)
-.. `FORCE_STAGING_BOOTSTRAP_PARAM` set to false (only for edge cases)
 .. `ONLY_STAGING_PARAM` set to true (we only want to stage, not publish)
 .. `ONLY_PROMOTION_PARAM` set to false (we only want to stage, not publish)
 
@@ -407,7 +406,6 @@ To do that, follow these steps:
 .. `GIT_STAGING_REPOSITORY_PROMOTION_ENABLED` set to false (manually merged by security team)
 .. `VALIDATION_ENABLED` set to true (we want a summary of what need to be done at the beginning)
 .. `WINDOWS_PACKAGING_ENABLED` set to **false** (no package generation)
-.. `FORCE_STAGING_BOOTSTRAP_PARAM` set to false (only for edge cases)
 .. `ONLY_STAGING_PARAM` set to **false** (we don't want to stage anything)
 .. `ONLY_PROMOTION_PARAM` set to **true** (we only want to publish)
 

--- a/utils/release.bash
+++ b/utils/release.bash
@@ -463,12 +463,6 @@ function showPackagingPlan() {
 			exit 1
 		fi
 
-		if [ "${FORCE_STAGING_BOOTSTRAP:-false}" == "true" ]
-		then
-			echo "ERROR: you can't disable staging (ONLY_PROMOTION=true) while forcing for a staging bootstrap (FORCE_STAGING_BOOTSTRAP=true)."
-			exit 1
-		fi
-
 		cat <<-EOF
 			The ${release_packages_description}
 			staged in ${BASE_BIN_DIR} and ${BASE_PKG_DIR} will be promoted (e.g. published)
@@ -578,28 +572,16 @@ function prepareStaging() {
 
 	set +u
 	local rpmreleaseline="rpm${RELEASELINE}"
-	local debianreleaseline="rpm${RELEASELINE}"
 	set -u
 
-	# Bootstrap (e.g. reset to production) all stagings for this branch if requested by the user or if missing a directory
-	if [ "${FORCE_STAGING_BOOTSTRAP}" = "true" ] || [ ! -d "${BASE_BIN_DIR}" ] || [ ! -d "${BASE_PKG_DIR}" ]
-	then
-		echo "Bootstrap (reset to production) of the staging environment for ${BASE_BIN_DIR} and ${BASE_PKG_DIR} directories..."
-		rm -rf "${BASE_BIN_DIR}" "${BASE_PKG_DIR}"
-		mkdir -p "${BASE_BIN_DIR}" "${BASE_PKG_DIR}"
+	rm -rf "${BASE_BIN_DIR}" "${BASE_PKG_DIR}"
+	mkdir -p "${BASE_BIN_DIR}" "${BASE_PKG_DIR}"
 
-		# TODO: Initialize from production with symlinks?
-		# Initialize from production only for RPMs to get the history when rebuilding index (Debian don't care)
-		rsync -avtz --chown=1000:1000 \
-			"${GET_JENKINS_IO_PRODUCTION}/${rpmreleaseline}" \
-			"${BASE_BIN_DIR}/"
-
-		# Initialize from production as we need an initial package state.
-		rsync -avtz --chown=1000:1000 \
-			"${PKG_JENKINS_IO_PRODUCTION}/${rpmreleaseline}" \
-			"${PKG_JENKINS_IO_PRODUCTION}/${debianreleaseline}" \
-			"${BASE_PKG_DIR}/"
-	fi
+	# TODO: Initialize from production with symlinks?
+	# Initialize from production only for RPMs to get the history when rebuilding index (Debian merges production index with the new one instead)
+	rsync -avtz --chown=1000:1000 \
+		"${GET_JENKINS_IO_PRODUCTION}/${rpmreleaseline}" \
+		"${BASE_BIN_DIR}/"
 }
 
 function checkPackagingEnvironment() {


### PR DESCRIPTION
Ref. https://github.com/jenkinsci/packaging/issues/717#issuecomment-3679323475


Note: this PR also removes the initial copy of Debian and RPM content from pkg.jenkins.io production:

- Debian does not need this initial copy as it [retrieve the `https://pkg.jenkins.io/debian${releaseline}` from production](https://github.com/jenkinsci/packaging/blob/1e2834d5678bfa5b240c7f721e012d28807da199/deb/publish/publish.sh#L47C1-L47C92)
  - Besides it was a "no-op" on previous releases as the shell variable removed in this PR for debian had a wrong value (`local debianreleaseline="rpm${RELEASELINE}"`).
- RPM index directory should be initialized empty. It only needs the former packages (e.g. staging.get from get.jio production, not pkg).