### PR TITLE
fix(package/utils) always bootstrap staging from scratch with only RPM packages from before 

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -64,11 +64,6 @@ pipeline {
     )
     booleanParam(
       defaultValue: false,
-      description: 'Force bootstrap (cleanup + initialization from production) of the packages staging environment if data from previous staged build is present.',
-      name: 'FORCE_STAGING_BOOTSTRAP_PARAM'
-    )
-    booleanParam(
-      defaultValue: false,
       description: 'Select this checkbox if you want to disable promotion to production (e.g. only publish to staging).',
       name: 'ONLY_STAGING_PARAM'
     )
@@ -115,7 +110,6 @@ pipeline {
     BASE_BIN_DIR              = "${env.GET_JENKINS_IO_STAGING}/${env.BRANCH_NAME.replaceAll('\\.', '_').replaceAll('\\/', '_').replaceAll('\\:', '_')}"
     // Sanitize URL to avoid nested subdomains and other URL bad surprises: "feat/foo-stable:2.539" => "feat_foo-stable_2_539"
     BASE_PKG_DIR              = "${env.PKG_JENKINS_IO_STAGING}/${env.BRANCH_NAME.replaceAll('\\.', '_').replaceAll('\\/', '_').replaceAll('\\:', '_')}"
-    FORCE_STAGING_BOOTSTRAP   = "${params.containsKey("FORCE_STAGING_BOOTSTRAP_PARAM") ? params.FORCE_STAGING_BOOTSTRAP_PARAM : false}"
     ONLY_STAGING              = "${params.containsKey("ONLY_STAGING_PARAM") ? params.ONLY_STAGING_PARAM : false}"
     ONLY_PROMOTION            = "${params.containsKey("ONLY_PROMOTION_PARAM") ? params.ONLY_PROMOTION_PARAM : false}"
   }

--- a/README.adoc
+++ b/README.adoc
@@ -391,7 +391,6 @@ To do that, follow these steps:
 .. `GIT_STAGING_REPOSITORY_PROMOTION_ENABLED` set to false (manually merged by security team)
 .. `VALIDATION_ENABLED` set to true (we want a summary of what need to be done at the beginning)
 .. `WINDOWS_PACKAGING_ENABLED` set to true (we want to generate and stage Windows package along with other packages)
-.. `FORCE_STAGING_BOOTSTRAP_PARAM` set to false (only for edge cases)
 .. `ONLY_STAGING_PARAM` set to true (we only want to stage, not publish)
 .. `ONLY_PROMOTION_PARAM` set to false (we only want to stage, not publish)
 
@@ -407,7 +406,6 @@ To do that, follow these steps:
 .. `GIT_STAGING_REPOSITORY_PROMOTION_ENABLED` set to false (manually merged by security team)
 .. `VALIDATION_ENABLED` set to true (we want a summary of what need to be done at the beginning)
 .. `WINDOWS_PACKAGING_ENABLED` set to **false** (no package generation)
-.. `FORCE_STAGING_BOOTSTRAP_PARAM` set to false (only for edge cases)
 .. `ONLY_STAGING_PARAM` set to **false** (we don't want to stage anything)
 .. `ONLY_PROMOTION_PARAM` set to **true** (we only want to publish)
 


### PR DESCRIPTION
Ref. https://github.com/jenkinsci/packaging/issues/717#issuecomment-3679323475


Note: this PR also removes the initial copy of Debian and RPM content from pkg.jenkins.io production:

- Debian does not need this initial copy as it [retrieve the `https://pkg.jenkins.io/debian${releaseline}` from production](https://github.com/jenkinsci/packaging/blob/1e2834d5678bfa5b240c7f721e012d28807da199/deb/publish/publish.sh#L47C1-L47C92)
  - Besides it was a "no-op" on previous releases as the shell variable removed in this PR for debian had a wrong value (`local debianreleaseline="rpm${RELEASELINE}"`).
- RPM index directory should be initialized empty. It only needs the former packages (e.g. staging.get from get.jio production, not pkg).

----

Tests run:

- A first build to parse parameters and immediately cancelled (as we want to remove the `FORCE_STAGING_BOOTSTRAP_PARAM` pipeline parameter)
- A second build with the Jenkins version specified to `2.541` and the line set to `weekly`:
  - ✅ https://staging.get.jenkins.io/fix_staging_always-cleanup/ only shows the 2.541 binaries as expected in `/war`, `/windows` and `/debian` with the `latest` symlinks set to 2.541 for `/war` and `/windows`. `/rpm` shows all RPMs since 2.537 but 2.541 is timestamped with the build execution time (showing it was updated from existing production RPM).
  - ✅ https://fix_staging_always-cleanup.staging.pkg.origin.jenkins.io/ only shows the `/rpm` and `/debian` folders which can be used to install 2.541 from https://staging.get.jenkins.io/fix_staging_always-cleanup/ instead of production (checking with logs).
- A third build with the Jenkins version specified to `2.542` and the line set to `weekly`: 
  - ✅ https://staging.get.jenkins.io/fix_staging_always-cleanup/ only shows the 2.542 binaries as expected in `/war`, `/windows` and `/debian` and the `latest` symlinks set to 2.542 for `/war` and `/windows`. There should be NO 2.541 binary files (cleaned up). . `/rpm` shows all RPMs since 2.537 but 2.542 is timestamped with the build execution time (showing it was updated from existing production RPM). 
  - ✅ https://fix_staging_always-cleanup.staging.pkg.origin.jenkins.io/ only shows the `/rpm` and `/debian` folders which can be used to install 2.542 from https://staging.get.jenkins.io/fix_staging_always-cleanup/ instead of production (checking with logs).
- A fourth build with the Jenkins version specified to `2.528.3` and the line set to `stable`
  - ✅ https://staging.get.jenkins.io/fix_staging_always-cleanup/ only shows the 2.528.3 binaries as expected in `/war-stable`, `/windows-stable`, `/rpm-stable` (assuming unified RPMs, there should be only 1 RPM as none in production) and `/debian-stable` with the `latest` symlinks set to 2.528.3 for `/war-stable` and `/windows-stable`. There should be NO more `/war`, `/windows`, `/rpm` and `/debian` (cleaned up).
  - ✅ The https://fix_staging_always-cleanup.staging.pkg.origin.jenkins.io/ web service only shows the `/rpm-stable` and `/debian-stable` folders which can be used to install 2.528.3 from https://staging.get.jenkins.io/fix_staging_always-cleanup/ instead of production (checking with logs). There should be NO more `/rpm` or `/debian` (cleaned up).