### PR TITLE
cleanup(package) stop utilizing the former AWS pkg.origin.jenkins.io virtual machine

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -331,7 +331,6 @@ pipeline {
       }
       environment {
         SSH_HOSTKEY_ARCHIVES_JENKINS_IO   = credentials('ssh-hostkey-archives.jenkins.io')
-        SSH_HOSTKEY_PKG_ORIGIN_JENKINS_IO = credentials('ssh-hostkey-pkg.origin.jenkins.io')
       }
       steps {
         sshagent(credentials: [

--- a/Jenkinsfile.d/infra-agents-health
+++ b/Jenkinsfile.d/infra-agents-health
@@ -32,7 +32,6 @@ pipeline {
           }
           environment {
             SSH_HOSTKEY_ARCHIVES_JENKINS_IO = credentials('ssh-hostkey-archives.jenkins.io')
-            SSH_HOSTKEY_PKG_ORIGIN_JENKINS_IO = credentials('ssh-hostkey-pkg.origin.jenkins.io')
           }
           steps {
             checkout scm
@@ -63,9 +62,8 @@ pipeline {
             ]) {
               sh '''
               mkdir -m 700 -p "${HOME}/.ssh"
-              cat "${SSH_HOSTKEY_ARCHIVES_JENKINS_IO}" "${SSH_HOSTKEY_PKG_ORIGIN_JENKINS_IO}" >> "${HOME}/.ssh/known_hosts"
+              cat "${SSH_HOSTKEY_ARCHIVES_JENKINS_IO}" >> "${HOME}/.ssh/known_hosts"
               ssh -v mirrorsync@archives.jenkins.io whoami
-              ssh -v mirrorbrain@pkg.origin.jenkins.io whoami
               '''
             }
           }

--- a/utils/release.bash
+++ b/utils/release.bash
@@ -558,18 +558,7 @@ function promotePackages() {
 		--exclude=/plugins `# populated by https://github.com/jenkins-infra/update-center2` \
 		. `# source` \
 		"${PKG_JENKINS_IO_PRODUCTION}"
-	# TODO: remove once fully migrated to Azure
-	rsync --recursive \
-		--links `# Copy symlinks as symlinks: destination is a Linux filesystem` \
-		--perms `# Preserve permissions: destination is a Linux filesystem` \
-		--devices --specials `# Preserve special files: destination is a Linux filesystem` \
-		--compress `# CPU is cheap, bandwidth is not` \
-		--verbose \
-		--times `# Preserve timestamps` \
-		--chown="mirrorbrain:www-data" `# Ensure the right ownership to have read-only on the webserver` \
-		--exclude=/plugins `# populated by https://github.com/jenkins-infra/update-center2` \
-		. `# source` \
-		mirrorbrain@pkg.origin.jenkins.io:/var/www/pkg.jenkins.io `# destination`
+
 	popd
 }
 


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3705#issuecomment-3681480718

This PR removes all references to the `pkg.origin.jenkins.io` AWS machine which we should not use anymore (see associated issue and comments).


Note: this PR is expected to fix the "Infra Agent Health" job on release.ci.jenkins.io. See https://github.com/jenkins-infra/helpdesk/issues/4921#issuecomment-3681540785. Tested manually with success with a run of the Infra Agent Health" (https://release.ci.jenkins.io/job/Infra%20Agents%20Health/252/). Will verify once merge with the same job.