### PR TITLE
fix(Github/issue-templates/LTS) use correct order for Packaging items and details how to safely create branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
@@ -44,7 +44,7 @@ This role should rotate between LTS releases
   - [ ] Modify the `PACKAGING_GIT_BRANCH` value in the packaging script (`Jenkinsfile.d/core/package`) to match the release.
   - For more info, refer to [stable](https://github.com/jenkins-infra/release#stable).
 
-- [ ] Check with the Jenkins Infrastructure team for backports on both repositories [jenkinsci/packaging](https://github.com/jenkinsci/packaging) and [jenkins-infra/release](https://github.com/jenkins-infra/release)
+- [ ] Check with the Jenkins Infrastructure team for backports on both repositories [jenkinsci/packaging](https://github.com/jenkinsci/packaging) and [jenkins-infra/release](https://github.com/jenkins-infra/release) as per https://github.com/jenkins-infra/release/blob/master/docs/releases.md#open-a-backporting-pr.
   - A message in the Matrix channel `#jenkins-infra` mentioning this issue and this item is enough: they will own the backports
 
 - [ ] Create a pull request to update [bom](https://github.com/jenkinsci/bom) to the weekly version that will be the base of the release line (and strike this out for new point release).


### PR DESCRIPTION
Ref. https://matrix.to/#/!JlkqzpdEnsUUuVtjgE:matrix.org/$olm02oN5EoeogavXxEZCZQDmzWQe0esA5DINijfEVlQ?via=matrix.org&via=gitter.im

> [LTS 2.541.1: jenkinsci/packaging and jenkins-infra/release] Herve and I are currently reviewing the backports candidates for PACKAGING ONLY (and the associated INFRA changes).
>
> We caught a potential major hiccup with the branch stable-2.541 created on the repository jenkins-infra/packaging which was created from an incorrect commit of the master branch. It accidentally includes the removal of JDK17 on the Windows installer which was ABSENT from 2.541 weekly.
> 
> The root cause is the LTS task list missing details on how to create this branch (since jenkinsci/packaging does NOT have a shell script to do it unlike jenkins-infra/release) so the release lead cannot know this.


This PR proposes to update the issue template to avoid this problem in the future.

Once merged, I'll update https://github.com/jenkins-infra/release/issues/811 with the changes.