### PR TITLE
fix(package) ensure the new Fastly credential is used

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -346,7 +346,7 @@ pipeline {
       }
       environment {
         FASTLY_API_TOKEN = credentials('fastly-api-token')
-        FASTLY_SERVICE_ID = credentials('fastly_pkgserver_service_id')
+        FASTLY_SERVICE_ID = credentials('fastly_pkgjenkinsio_service_id')
       }
       steps {
         sh '''


### PR DESCRIPTION
ref. https://github.com/jenkins-infra/kubernetes-management/pull/7403

Note: requires backport on the `stable-2.541` and `stable-2.528` branches