### PR TITLE
chore(infra-agents-health) remove unused credential

### DIFF
--- a/Jenkinsfile.d/infra-agents-health
+++ b/Jenkinsfile.d/infra-agents-health
@@ -57,7 +57,6 @@ pipeline {
 
             // Ensure we can SSH-connect to required remote servers
             sshagent(credentials: [
-              'pkgserver',
               'archives.jenkins.io'
             ]) {
               sh '''


### PR DESCRIPTION
Follow up of removing this credential in https://github.com/jenkins-infra/kubernetes-management/pull/7403

Note: will need backport to 2.528 and 2.541 lines