### PR TITLE
fix(Jenkinsfile.d/release): force recalculation of maven metadata only in public releases

### DIFF
--- a/Jenkinsfile.d/core/release
+++ b/Jenkinsfile.d/core/release
@@ -139,7 +139,10 @@ pipeline {
           # Ensure Artifactory updates the `latest` field in the `jenkins-war` 's `maven-metadata.xml` (sometime it is not updated).
           # Note 1: only useful for weekly releases (no op for LTS)
           # Note 2: Could the "bug" being caused by only using Maven `release:stage` instead of `release:perform`?
-          curl -X POST -H 'Content-Length: 0' --fail --user "${MAVEN_REPOSITORY_USERNAME}:${MAVEN_REPOSITORY_PASSWORD}" "https://repo.jenkins-ci.org/api/maven/calculateMetadata/releases/org/jenkins-ci/main/jenkins-war/"
+          # Note 3: don't update maven-metadata if not a public release
+          if [[ "${MAVEN_REPOSITORY_NAME}" == "releases" ]]; then
+            curl -X POST -H 'Content-Length: 0' --fail --user "${MAVEN_REPOSITORY_USERNAME}:${MAVEN_REPOSITORY_PASSWORD}" "https://repo.jenkins-ci.org/api/maven/calculateMetadata/releases/org/jenkins-ci/main/jenkins-war/"
+          fi
         '''
       }
     }


### PR DESCRIPTION
Amends:
- https://github.com/jenkins-infra/release/pull/755

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5000#issuecomment-3909548627