### PR TITLE
hotfix: don't hardcode `releases` maven repository name

### DIFF
--- a/Jenkinsfile.d/core/release
+++ b/Jenkinsfile.d/core/release
@@ -135,11 +135,6 @@ pipeline {
       steps {
         sh '''
           utils/release.bash --stageRelease
-
-          # Ensure Artifactory updates the `latest` field in the `jenkins-war` 's `maven-metadata.xml` (sometime it is not updated).
-          # Note 1: only useful for weekly releases (no op for LTS)
-          # Note 2: Could the "bug" being caused by only using Maven `release:stage` instead of `release:perform`?
-          curl -X POST -H 'Content-Length: 0' --fail --user "${MAVEN_REPOSITORY_USERNAME}:${MAVEN_REPOSITORY_PASSWORD}" "https://repo.jenkins-ci.org/api/maven/calculateMetadata/releases/org/jenkins-ci/main/jenkins-war/"
         '''
       }
     }

--- a/utils/release.bash
+++ b/utils/release.bash
@@ -416,6 +416,14 @@ function stageRelease() {
 		-s settings-release.xml \
 		-ntp \
 		release:stage
+
+	# Update maven-metadata only if it's a public release
+	if [[ "${MAVEN_REPOSITORY_NAME}" == "releases" ]]; then
+		# Ensure Artifactory updates the `latest` field in the `jenkins-war` 's `maven-metadata.xml` (sometime it is not updated).
+		# Note 1: only useful for weekly releases (no op for LTS)
+		# Note 2: Could the "bug" being caused by only using Maven `release:stage` instead of `release:perform`?
+		curl -X POST -H 'Content-Length: 0' --fail --user "${MAVEN_REPOSITORY_USERNAME}:${MAVEN_REPOSITORY_PASSWORD}" "https://repo.jenkins-ci.org/api/maven/calculateMetadata/${MAVEN_REPOSITORY_NAME}/org/jenkins-ci/main/jenkins-war/"
+	fi
 }
 
 function performRelease() {


### PR DESCRIPTION
This change removes remaining cases of hardcoded `releases` in release.bash script.

For that, it also includes https://github.com/jenkins-infra/release/commit/5837f23a4eeed93aeabda2f0797387fd87e74879 (proper version of #850).
To be backported to `security-2.551` too?

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5000#issuecomment-3914639331