### PR TITLE
fix: include `release.bash` fixes from jenkins-infra/helpdesk#5000 in `stable-2.541`

### DIFF
--- a/Jenkinsfile.d/core/release
+++ b/Jenkinsfile.d/core/release
@@ -135,14 +135,6 @@ pipeline {
       steps {
         sh '''
           utils/release.bash --stageRelease
-
-          # Ensure Artifactory updates the `latest` field in the `jenkins-war` 's `maven-metadata.xml` (sometime it is not updated).
-          # Note 1: only useful for weekly releases (no op for LTS)
-          # Note 2: Could the "bug" being caused by only using Maven `release:stage` instead of `release:perform`?
-          # Note 3: don't update maven-metadata if not a public release
-          if [[ "${MAVEN_REPOSITORY_NAME}" == "releases" ]]; then
-            curl -X POST -H 'Content-Length: 0' --fail --user "${MAVEN_REPOSITORY_USERNAME}:${MAVEN_REPOSITORY_PASSWORD}" "https://repo.jenkins-ci.org/api/maven/calculateMetadata/releases/org/jenkins-ci/main/jenkins-war/"
-          fi
         '''
       }
     }

--- a/utils/release.bash
+++ b/utils/release.bash
@@ -124,13 +124,13 @@ function downloadJenkinsWar() {
 	jenkinsVersion="$(jv get)" # jv utilizes the JENKINS_VERSION environment variable which can be the line (latest/weekly/lts/stable) or an exact version
 
 	# Download WAR from Artifactory. Note: the expected filename is "jenkins.war".
-	warUrl="https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/${jenkinsVersion}/jenkins-war-${jenkinsVersion}.war"
-	curl --fail --silent --show-error --location --output "${WAR}" \
+	warUrl="https://repo.jenkins-ci.org/${MAVEN_REPOSITORY_NAME}/org/jenkins-ci/main/jenkins-war/${jenkinsVersion}/jenkins-war-${jenkinsVersion}.war"
+	curl --fail --silent --show-error --location --user "${MAVEN_REPOSITORY_USERNAME}:${MAVEN_REPOSITORY_PASSWORD}" --output "${WAR}" \
 		"${warUrl}"
 
 	# Download signature from Artifactory (signed by Maven during the release process). Note: the expected filename is "jenkins.war.asc".
 	warSignatureUrl="${warUrl}.asc"
-	curl --fail --silent --show-error --location --output "${WAR}.asc" \
+	curl --fail --silent --show-error --location --user "${MAVEN_REPOSITORY_USERNAME}:${MAVEN_REPOSITORY_PASSWORD}" --output "${WAR}.asc" \
 		"${warSignatureUrl}"
 
 	# TODO: verify the download. Requires retrieving the correct GPG key (edge case when rotating key, might need to use state files)
@@ -416,6 +416,14 @@ function stageRelease() {
 		-s settings-release.xml \
 		-ntp \
 		release:stage
+
+	# Update maven-metadata only if it's a public release
+	if [[ "${MAVEN_REPOSITORY_NAME}" == "releases" ]]; then
+		# Ensure Artifactory updates the `latest` field in the `jenkins-war` 's `maven-metadata.xml` (sometime it is not updated).
+		# Note 1: only useful for weekly releases (no op for LTS)
+		# Note 2: Could the "bug" being caused by only using Maven `release:stage` instead of `release:perform`?
+		curl -X POST -H 'Content-Length: 0' --fail --user "${MAVEN_REPOSITORY_USERNAME}:${MAVEN_REPOSITORY_PASSWORD}" "https://repo.jenkins-ci.org/api/maven/calculateMetadata/${MAVEN_REPOSITORY_NAME}/org/jenkins-ci/main/jenkins-war/"
+	fi
 }
 
 function performRelease() {


### PR DESCRIPTION
Includes changes from:
- #853
- #854
- #856
- #857

Backport of:
- #861 

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5000