### PR TITLE
feat! Switch agents to JDK25

### DIFF
--- a/PodTemplates.d/package-linux.yaml
+++ b/PodTemplates.d/package-linux.yaml
@@ -14,7 +14,7 @@ spec:
       imagePullPolicy: "IfNotPresent"
       env:
         - name: "JENKINS_JAVA_BIN"
-          value: "/opt/jdk-21/bin/java"
+          value: "/opt/jdk-25/bin/java"
         - name: "JENKINS_JAVA_OPTS"
           value: "-XX:+PrintCommandLineFlags"
         - name: "GET_JENKINS_IO_STAGING"

--- a/PodTemplates.d/package-windows.yaml
+++ b/PodTemplates.d/package-windows.yaml
@@ -16,7 +16,7 @@ spec:
     name: "jnlp"
     env:
       - name: "JENKINS_JAVA_BIN"
-        value: "C:/openjdk-21/bin/java"
+        value: "C:/openjdk-25/bin/java"
       - name: "JENKINS_JAVA_OPTS"
         value: '"-XX:+PrintCommandLineFlags" --show-version'
     resources:

--- a/PodTemplates.d/release-linux.yaml
+++ b/PodTemplates.d/release-linux.yaml
@@ -18,7 +18,7 @@ spec:
         - name: "MAVEN_OPTS"
           value: "-Xmx8g -Xms8g"
         - name: "JENKINS_JAVA_BIN"
-          value: "/opt/jdk-21/bin/java"
+          value: "/opt/jdk-25/bin/java"
         - name: "JENKINS_JAVA_OPTS"
           value: "-XX:+PrintCommandLineFlags"
       resources:


### PR DESCRIPTION
Related to:

- https://github.com/jenkins-infra/helpdesk/issues/4941

This PR sets the agents JDK version to jdk25 (runtime)  to proceed with the upgrade of release.ci agents to jdk25