### PR TITLE
Backport of `master` into `stable-2.555` for LTS 2.555.1 release

### DIFF
--- a/PodTemplates.d/package-linux.yaml
+++ b/PodTemplates.d/package-linux.yaml
@@ -10,7 +10,7 @@ spec:
   serviceAccountName: release-ci-jenkins-io-agents
   containers:
     - name: jnlp
-      image: jenkinsciinfra/packaging:9.1.1
+      image: jenkinsciinfra/packaging:9.1.6
       imagePullPolicy: "IfNotPresent"
       env:
         - name: "JENKINS_JAVA_BIN"

--- a/PodTemplates.d/package-windows.yaml
+++ b/PodTemplates.d/package-windows.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   serviceAccountName: release-ci-jenkins-io-agents
   containers:
-  - image: jenkins/inbound-agent:3355.v388858a_47b_33-15-jdk25-nanoserver-ltsc2022
+  - image: jenkins/inbound-agent:3355.v388858a_47b_33-17-jdk25-nanoserver-ltsc2022
     imagePullPolicy: "IfNotPresent"
     name: "jnlp"
     env:

--- a/PodTemplates.d/release-linux.yaml
+++ b/PodTemplates.d/release-linux.yaml
@@ -10,7 +10,7 @@ spec:
   serviceAccountName: release-ci-jenkins-io-agents
   containers:
     - name: jnlp
-      image: jenkinsciinfra/packaging:9.1.1
+      image: jenkinsciinfra/packaging:9.1.6
       imagePullPolicy: "IfNotPresent"
       env:
         - name: "HOME"


### PR DESCRIPTION
Backport of #878

I've skipped https://github.com/jenkins-infra/release/pull/876 as we don't care about weekly releases from this stable-2.555 branch.

Ref:
- https://github.com/jenkins-infra/release/issues/880