### PR TITLE
chore(infra-agent-health): publish build status report

### DIFF
--- a/Jenkinsfile.d/infra-agents-health
+++ b/Jenkinsfile.d/infra-agents-health
@@ -1,3 +1,11 @@
+library(
+  identifier: 'pipeline-library@master',
+  retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/jenkins-infra/pipeline-library.git',
+  ])
+)
+
 pipeline {
   agent none
 
@@ -109,6 +117,16 @@ pipeline {
             }
           }
         }
+      }
+    }
+    stage('Publish build status report') {
+      agent {
+        kubernetes {
+          yamlFile 'PodTemplates.d/release-linux.yaml'
+        }
+      }
+      steps {
+        publishBuildStatusReport()
       }
     }
   }


### PR DESCRIPTION
This change adds a step to publish build status reports from this job.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2843

#### Testing done

Replay:
- https://release.ci.jenkins.io/job/infra-agents-health/386
- https://builds.reports.jenkins.io/build_status_reports/release.ci.jenkins.io/infra-agents-health/status.json

Note: I had to rename the "Infra Agent Health" job on release.ci.jenkins.io to "infra-agent-health" to avoid failure on unquoted workspace name: https://release.ci.jenkins.io/job/infra-agents-health/385/stages/?start-byte=0&selected-node=98#log-98-1
```
22:59:12  + bash /home/jenkins/agent/workspace/Infra Agents Health@tmp/generateAndWriteBuildStatusReport.sh
22:59:12  bash: /home/jenkins/agent/workspace/Infra: No such file or directory
script returned exit code 127
```