### PR TITLE
feat(packaging/windows) sign MSI installer using with Linux Foundation Azure service

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -95,7 +95,6 @@ pipeline {
     // Using HTTPS with no credentials - https://github.com/jenkins-infra/helpdesk/issues/4909 - need a GH app if rate limited or need to write things to git
     PACKAGING_GIT_REPOSITORY  = 'https://github.com/jenkinsci/packaging.git'
     PACKAGING_GIT_BRANCH      = 'master'
-    SIGN_KEYSTORE_FILENAME    = 'jenkins.pfx'
     SIGN_STOREPASS            = credentials('signing-cert-pass-2023')
     WAR_FILENAME              = 'jenkins.war'
     WAR                       = "$WORKSPACE/$WORKING_DIRECTORY/$WAR_FILENAME"
@@ -104,8 +103,6 @@ pipeline {
     MSI_FILENAME              = 'jenkins.msi'
     MSI                       = "$WORKSPACE/$WORKING_DIRECTORY/$MSI_FILENAME"
     WORKING_DIRECTORY         = "release"
-    PKCS12_FILE               = "$WORKSPACE/$WORKING_DIRECTORY/jenkins.pfx" // Created by SIGN_KEYSTORE
-    PKCS12_PASSWORD_FILE      = credentials('signing-cert-pass-2023')
     // Sanitize URL to avoid nested subdomains and other URL bad surprises: "feat/foo-stable:2.539" => "feat_foo-stable_2_539"
     BASE_BIN_DIR              = "${env.GET_JENKINS_IO_STAGING}/${env.BRANCH_NAME.replaceAll('\\.', '_').replaceAll('\\/', '_').replaceAll('\\:', '_')}"
     // Sanitize URL to avoid nested subdomains and other URL bad surprises: "feat/foo-stable:2.539" => "feat_foo-stable_2_539"
@@ -156,16 +153,6 @@ pipeline {
             }
 
             sh './utils/release.bash --configureGPG'
-          }
-        }
-        stage('Get Code Signing Certificate') {
-          steps {
-            sh '''
-              utils/release.bash --downloadAzureKeyvaultSecret
-              utils/release.bash --configureKeystore
-            '''
-
-            stash includes: SIGN_KEYSTORE_FILENAME, name: 'KEYSTORE'
           }
         }
         stage('Prepare package staging environment') {
@@ -242,39 +229,66 @@ pipeline {
                 }
               }
             }
-            stage('Windows') {
+            stage('MSI') {
               when {
                 environment name: 'WINDOWS_PACKAGING_ENABLED', value: 'true'
               }
               stages {
-                stage('Build') {
-                  // Windows requirement: Every steps need to be executed inside default jnlp
-                  // as the step 'container' is known to not be working
+                stage('Windows') {
                   agent {
                     kubernetes {
                       yamlFile 'PodTemplates.d/package-windows.yaml'
                     }
                   }
-                  steps {
-                    container('dotnet') {
-                      checkout scm
-                      dir (WORKING_DIRECTORY) {
-                        git branch: PACKAGING_GIT_BRANCH, url: PACKAGING_GIT_REPOSITORY
+                  stages {
+                    stage('Build MSI') {
+                      steps {
+                        container('build-dotnet') {
+                          checkout scm
+                          dir (WORKING_DIRECTORY) {
+                            git branch: PACKAGING_GIT_BRANCH, url: PACKAGING_GIT_REPOSITORY
 
-                        unstash 'GPG'
-                        unstash 'WAR'
-                        unstash 'KEYSTORE'
+                            unstash 'WAR'
 
-                        powershell '''
-                          Get-ChildItem env:
-                          $env:WAR=(Resolve-Path .\\jenkins.war).Path
-                          & .\\make.ps1
-                        '''
-                        // Don't archive the full path
-                        dir('msi\\build\\bin\\Release\\en-US') {
-                          archiveArtifacts '*.msi*'
+                            powershell '''
+                              Get-ChildItem env:
+                              $env:WAR=(Resolve-Path .\\jenkins.war).Path
+                              & .\\make.ps1
+                            '''
+                          }
                         }
+                      }
+                    }
+                    stage('Prepare Signing') {
+                      steps {
+                        container('sign-dotnet') {
+                          /***
+                          TODO: migrate to a prebuilt container image or VM to avoid installing on each run
+                          ***/
+                          powershell '''
+                          & .\\utils\\msi-setup-signing.ps1
+                          '''
+                        }
+                      }
+                    }
+                    stage('Sign MSI') {
+                      environment {
+                        // Using default Azure SDK variables, not expecting other Azure usage (az / azcopy/etc.) than signing for this stage (as these credentials are related to Linux Foundation tenant, not our tenant)
+                        AZURE_TENANT_ID                         = credentials('lf-msi-sign-azure-tenant-id')
+                        AZURE_CLIENT_ID                         = credentials('lf-msi-sign-azure-client-id')
+                        AZURE_CLIENT_SECRET                     = credentials('lf-msi-sign-azure-client-secret')
+                      }
+                      steps {
+                        container('sign-dotnet') {
+                          powershell '''
+                          & .\\utils\\msi-sign.ps1
+                          '''
 
+                          // Don't archive the full path
+                          dir('release\\msi\\build\\bin\\Release\\en-US') {
+                            archiveArtifacts '*.msi*'
+                          }
+                        }
                       }
                     }
                   }

--- a/PodTemplates.d/package-windows.yaml
+++ b/PodTemplates.d/package-windows.yaml
@@ -2,12 +2,9 @@ apiVersion: "v1"
 kind: "Pod"
 metadata:
   labels:
-    jenkins: "slave"
     job: "package"
     #Following label is required by the workload identity process https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview?tabs=dotnet#pod-labels
     azure.workload.identity/use: "true"
-    #Following label is required by the NetworkPolicy managed by stable/jenkins helm chart and configured from jenkins-infra/charts
-    jenkins/default-release-jenkins-agent: true
 spec:
   serviceAccountName: release-ci-jenkins-io-agents
   containers:
@@ -22,9 +19,9 @@ spec:
     resources:
       limits:
         memory: "4Gi"
-        cpu: "1"
+        cpu: "2"
       requests:
-        memory: "4Gi"
+        memory: "1Gi"
         cpu: "1"
   - args:
       - -Command
@@ -33,11 +30,29 @@ spec:
       - "powershell.exe"
     image: "mcr.microsoft.com/dotnet/framework/sdk:3.5-windowsservercore-ltsc2022"
     imagePullPolicy: "IfNotPresent"
-    name: "dotnet"
+    name: "build-dotnet"
     resources:
       limits:
+        memory: "8Gi"
+        cpu: "4"
+      requests:
         memory: "4Gi"
         cpu: "1"
+    securityContext:
+      privileged: false
+    tty: false
+  - args:
+      - -Command
+      - Start-Sleep -s 2147483 # We must be sure that the process used by the container doesn't stop before the Jenkins job and second is not greater than 2147483
+    command:
+      - "powershell.exe"
+    image: "mcr.microsoft.com/dotnet/runtime:8.0-windowsservercore-ltsc2022"
+    imagePullPolicy: "IfNotPresent"
+    name: "sign-dotnet"
+    resources:
+      limits:
+        memory: "8Gi"
+        cpu: "4"
       requests:
         memory: "4Gi"
         cpu: "1"

--- a/utils/msi-setup-signing.ps1
+++ b/utils/msi-setup-signing.ps1
@@ -11,7 +11,7 @@ Invoke-WebRequest -Uri "https://download.microsoft.com/download/70ad2c3b-761f-4a
 Start-Process msiexec.exe -Wait -ArgumentList '/I ArtifactSigningClientTools.msi /quiet';
 Remove-Item .\ArtifactSigningClientTools.msi;
 
-# Download nuget package manage (required below)
+# Download nuget package manager (required below)
 Invoke-WebRequest -Uri https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -OutFile .\nuget.exe
 
 # Download and install SignTool - https://learn.microsoft.com/en-us/azure/artifact-signing/how-to-signing-integrations#download-and-install-signtool

--- a/utils/msi-setup-signing.ps1
+++ b/utils/msi-setup-signing.ps1
@@ -1,0 +1,21 @@
+[CmdletBinding()]
+Param()
+
+$ProgressPreference = 'SilentlyContinue';
+Set-PSDebug -Trace 1
+
+# Artifact Signing Client Tools Installer - https://learn.microsoft.com/en-us/azure/artifact-signing/how-to-signing-integrations#installing-from-powershell
+# TODO: pin version
+# TODO: check if we can add to PATH during MSI installation
+Invoke-WebRequest -Uri "https://download.microsoft.com/download/70ad2c3b-761f-4aa9-a9de-e7405aa2b4c1/ArtifactSigningClientTools.msi" -OutFile .\ArtifactSigningClientTools.msi;
+Start-Process msiexec.exe -Wait -ArgumentList '/I ArtifactSigningClientTools.msi /quiet';
+Remove-Item .\ArtifactSigningClientTools.msi;
+
+# Download nuget package manage (required below)
+Invoke-WebRequest -Uri https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -OutFile .\nuget.exe
+
+# Download and install SignTool - https://learn.microsoft.com/en-us/azure/artifact-signing/how-to-signing-integrations#download-and-install-signtool
+.\nuget.exe install Microsoft.Windows.SDK.BuildTools -x
+
+# Download and install the Artifact Signing dlib package: https://learn.microsoft.com/en-us/azure/artifact-signing/how-to-signing-integrations#download-and-install-the-artifact-signing-dlib-package
+.\nuget.exe install Microsoft.ArtifactSigning.Client -x

--- a/utils/msi-sign.ps1
+++ b/utils/msi-sign.ps1
@@ -1,0 +1,22 @@
+[CmdletBinding()]
+Param(
+  # TODO: detect signtool.exe automatically to avoid bad surprise when the version changes
+  [String] $SigntoolPath    = ".\Microsoft.Windows.SDK.BuildTools\bin\10.0.28000.0\x64\signtool.exe",
+  [String] $CodeSigningDlibPath = ".\Microsoft.ArtifactSigning.Client\bin\x64\Azure.CodeSigning.Dlib.dll",
+  [String] $MSIPath = ".\release\msi\build\bin\Release\en-US\jenkins*.msi"
+)
+
+$ProgressPreference = 'SilentlyContinue';
+Set-PSDebug -Trace 1
+
+$MetadataPath = ".\metadata.json"
+@"
+{
+  "Endpoint": "https://eus.codesigning.azure.net/",
+  "CodeSigningAccountName": "LFOpenSourceLLC-Signing",
+  "CertificateProfileName": "CDF-Jenkins"
+}
+"@ | Set-Content $MetadataPath
+
+# Require Azure SD authentication (default to environment variables AZURE_TENANT_ID, AZURE_CLIENT_ID and AZURE_CLIENT_SECRET)
+& $SigntoolPath sign /v /debug /fd SHA256 /tr "http://timestamp.acs.microsoft.com" /td SHA256 /dlib $CodeSigningDlibPath /dmdf $MetadataPath $MSIPath


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4923

This is an initial implementation of the MSI signing using the Linux Foundation Azure Service.

It introduces an addition container in the Windows pod agent where the required tools are installed before signing. 
This additional container is required because dotnet 8.0+ is needed while we are still building the MSI with dotnet 3.x (our Wix setup fails on dotnet 8)

There is room for improvement of course for next iteration:

- The tooling should not be installed during the pipeline execution: we should have a prebuilt agent image in the future, to avoid surprises (version changed as the signtool.exe path has a version number in it and its not added to current user path when installed

Tested with https://release.ci.jenkins.io/job/core/job/package/job/helpdesk-4923%252Fmsi-lf-signing/44/ which published the freshly signed MSI for 2.561 in the (private) staging at https://staging.get.jenkins.io/helpdesk-4923_msi-lf-signing/windows/latest/

<img width="1019" height="768" alt="Capture d’écran 2026-04-24 à 21 16 11" src="https://github.com/user-attachments/assets/8e161a74-7824-48f5-ba91-8139a4125c49" />
