### PR TITLE
Set JENKINS_VERSION=2.555.2

### DIFF
--- a/profile.d/stable
+++ b/profile.d/stable
@@ -14,4 +14,4 @@ MAVEN_PUBLIC_JENKINS_REPOSITORY_MIRROR_URL='https://repo.jenkins-ci.org/public/'
 
 # Used by jenkinsci/packaging
 RELEASELINE=-stable
-JENKINS_VERSION=2.555.1
+JENKINS_VERSION=2.555.2


### PR DESCRIPTION
## Set JENKINS_VERSION=2.555.2

We missed that update in the earlier backporting pull request.  It is also not included in the release checklist.
