### PR TITLE
feat(infra-agents-health): add a daily cron trigger

### DIFF
--- a/Jenkinsfile.d/infra-agents-health
+++ b/Jenkinsfile.d/infra-agents-health
@@ -9,6 +9,10 @@ library(
 pipeline {
   agent none
 
+  triggers {
+    cron('0 2 * * *')
+  }
+
   options {
     disableConcurrentBuilds()
   }


### PR DESCRIPTION
This change adds a daily cron trigger to this pipeline as its job type changed from "Pipeline" to "Multibranch pipeline", thus the existing jobDSL syntax doesn't work anymore: https://github.com/jenkins-infra/kubernetes-management/blob/b47701062ec074e9982ff39bbe8c1353a633215a/config/privatek8s-sponsored/release.ci.jenkins.io.yaml#L199-L204

Fixup of:
- https://github.com/jenkins-infra/kubernetes-management/pull/7757

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5091#issuecomment-4381409952