### PR TITLE
chore(updatecli) fix service account manifest following `privatek8s` cleanup and fix deprecations

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -16,11 +16,11 @@ jobs:
       - name: Setup updatecli
         uses: updatecli/updatecli-action@e71be7554f3f940bc439cf720b3e4e379823c562 # v3.2.0
       - name: Diff
-        run: updatecli diff --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
+        run: updatecli pipeline diff --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Apply
         if: github.ref == 'refs/heads/master'
-        run: updatecli apply --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
+        run: updatecli pipeline apply --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/updatecli/updatecli.d/service-account.yaml
+++ b/updatecli/updatecli.d/service-account.yaml
@@ -19,6 +19,7 @@ sources:
     spec:
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
       key: .release\.ci\.jenkins\.io.agents_kubernetes_clusters.privatek8s-sponsored.agents_service_account
+      engine: dasel/v2
 
 targets:
   update-package-linux:

--- a/updatecli/updatecli.d/service-account.yaml
+++ b/updatecli/updatecli.d/service-account.yaml
@@ -18,7 +18,7 @@ sources:
     name: Retrieve Service Account for release.ci agents
     spec:
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
-      key: .release\.ci\.jenkins\.io.agents_kubernetes_clusters.privatek8s.agents_service_account
+      key: .release\.ci\.jenkins\.io.agents_kubernetes_clusters.privatek8s-sponsored.agents_service_account
 
 targets:
   update-package-linux:


### PR DESCRIPTION
This PR introduces the following changes in the `updatecli` process:

- Following [`privatek8s` cleanup](https://github.com/jenkins-infra/helpdesk/issues/5091#issuecomment-4554160116), the manifest tracking the service account was failing. Corrected with the new JSON path
- Remove deprecation around the upcoming deprecation of the `updatecli diff` and `updatecli apply` commands (using the `updatecli pipeline xxx` subcommand instead
- Remove warning around the parsing engine used with the JSON resources in the service account manifest, pinning it to `dasel/v2`