### PR TITLE
chore(jenkins/linux-agents) change Linux Pods node selectors for release.ci.jenkins.io in privatek8s-sponsored

### DIFF
--- a/PodTemplates.d/package-linux.yaml
+++ b/PodTemplates.d/package-linux.yaml
@@ -54,7 +54,7 @@ spec:
       persistentVolumeClaim:
         claimName: data-storage-jenkins-io
   nodeSelector:
-    kubernetes.azure.com/agentpool: releasepool
+    kubernetes.azure.com/agentpool: releacilinux
     kubernetes.io/os: linux
   tolerations:
     - key: "os"

--- a/PodTemplates.d/release-linux.yaml
+++ b/PodTemplates.d/release-linux.yaml
@@ -34,7 +34,7 @@ spec:
         runAsGroup: 1000
   restartPolicy: "Never"
   nodeSelector:
-    kubernetes.azure.com/agentpool: releasepool
+    kubernetes.azure.com/agentpool: releacilinux
     kubernetes.io/os: linux
   tolerations:
     - key: "os"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5091#issuecomment-4381409952

Backport of #908 into `stable-2.555` to ensure that the upcoming `2.555.3` core release will use it (required otherwise no agent will spawn on release.ci.jenkins.io)