### PR TITLE
chore(Jenkinsfile/package) stop archiving packages

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -161,14 +161,13 @@ pipeline {
             '''
           }
         }
-        stage('Download WAR archive to package') {
+        stage('Download WAR to package') {
           steps {
             sh '''
               ./utils/release.bash --downloadJenkins
             '''
             dir (WORKING_DIRECTORY) {
               stash includes: WAR_FILENAME, name: "WAR"
-              archiveArtifacts artifacts: "*.war"
             }
           }
         }
@@ -193,9 +192,6 @@ pipeline {
                     sh '''
                       ./utils/release.bash --packaging deb
                     '''
-                    dir (WORKING_DIRECTORY) {
-                      archiveArtifacts artifacts: "target/debian/*.deb"
-                    }
                   }
                 }
                 stage('Publish') {
@@ -214,9 +210,6 @@ pipeline {
                     sh '''
                       ./utils/release.bash --packaging rpm
                     '''
-                    dir (WORKING_DIRECTORY){
-                      archiveArtifacts artifacts: "target/rpm/*.rpm"
-                    }
                   }
                 }
                 stage('Publish'){
@@ -283,9 +276,9 @@ pipeline {
                           & .\\utils\\msi-sign.ps1
                           '''
 
-                          // Don't archive the full path
+                          // Don't stash the full path
                           dir('release\\msi\\build\\bin\\Release\\en-US') {
-                            archiveArtifacts '*.msi*'
+                            stash includes: '*.msi*' , name: 'MSI'
                           }
                         }
                       }
@@ -294,7 +287,7 @@ pipeline {
                 }
                 stage('Publish') {
                   steps {
-                    unarchive mapping: ['*.msi*': WORKING_DIRECTORY]
+                    unstash 'MSI'
                     sh '''
                       ./utils/release.bash --packaging msi.publish
                     '''


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5048

Backport of https://github.com/jenkins-infra/release/pull/912

This PR introduces the following change in the `package` pipeline: 

- Stop archiving generated artifacts and use stash/unstash (like the WAR) to avoid persisting packages in the build files


Notes:

- The Linux packages are directly generated into the NFS shared volume so no need to keep them on each build
- The Windows MSI can be stashed. I've changed the `unarchive` step by a `unstash`. Should be the same behavior, but to be carefully checked during next weekly release.