### PR TITLE
fix(Jenkinsfile/package) unstash MSI in the correct sub directory

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -287,7 +287,9 @@ pipeline {
                 }
                 stage('Publish') {
                   steps {
-                    unstash 'MSI'
+                    dir (WORKING_DIRECTORY) {
+                      unstash 'MSI'
+                    }
                     sh '''
                       ./utils/release.bash --packaging msi.publish
                     '''


### PR DESCRIPTION
Fixup of #912 where the `unarchive` step replaced by `unstash` was explicitly copying unarchive MSI files into the `WORKING_DIRECTORY` sub directory.

Verified with a replay (build 480 of package) to publish the weekly 2.567 version

Need to be backported to `stable-2.555`