### PR TITLE
Backport of `master` into `security-stable-2.555.3` for LTS 2.555.3 release

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -16,11 +16,11 @@ jobs:
       - name: Setup updatecli
         uses: updatecli/updatecli-action@4b17f4ea784de29f71f85f9bc4955402ba1ae53c # v2.100.0
       - name: Diff
-        run: updatecli diff --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
+        run: updatecli pipeline diff --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Apply
         if: github.ref == 'refs/heads/master'
-        run: updatecli apply --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
+        run: updatecli pipeline apply --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/PodTemplates.d/package-linux.yaml
+++ b/PodTemplates.d/package-linux.yaml
@@ -10,7 +10,7 @@ spec:
   serviceAccountName: release-ci-jenkins-io-agents
   containers:
     - name: jnlp
-      image: jenkinsciinfra/packaging:9.1.12
+      image: jenkinsciinfra/packaging:9.1.19
       imagePullPolicy: "IfNotPresent"
       env:
         - name: "JENKINS_JAVA_BIN"

--- a/PodTemplates.d/package-windows.yaml
+++ b/PodTemplates.d/package-windows.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   serviceAccountName: release-ci-jenkins-io-agents
   containers:
-  - image: jenkins/inbound-agent:3355.v388858a_47b_33-18-jdk25-nanoserver-ltsc2022
+  - image: jenkins/inbound-agent:3355.v388858a_47b_33-21-jdk25-nanoserver-ltsc2022
     imagePullPolicy: "IfNotPresent"
     name: "jnlp"
     env:

--- a/PodTemplates.d/release-linux.yaml
+++ b/PodTemplates.d/release-linux.yaml
@@ -10,7 +10,7 @@ spec:
   serviceAccountName: release-ci-jenkins-io-agents
   containers:
     - name: jnlp
-      image: jenkinsciinfra/packaging:9.1.12
+      image: jenkinsciinfra/packaging:9.1.19
       imagePullPolicy: "IfNotPresent"
       env:
         - name: "HOME"

--- a/updatecli/updatecli.d/service-account.yaml
+++ b/updatecli/updatecli.d/service-account.yaml
@@ -19,6 +19,7 @@ sources:
     spec:
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
       key: .release\.ci\.jenkins\.io.agents_kubernetes_clusters.privatek8s-sponsored.agents_service_account
+      engine: dasel/v2
 
 targets:
   update-package-linux:

--- a/updatecli/updatecli.d/service-account.yaml
+++ b/updatecli/updatecli.d/service-account.yaml
@@ -18,7 +18,7 @@ sources:
     name: Retrieve Service Account for release.ci agents
     spec:
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
-      key: .release\.ci\.jenkins\.io.agents_kubernetes_clusters.privatek8s.agents_service_account
+      key: .release\.ci\.jenkins\.io.agents_kubernetes_clusters.privatek8s-sponsored.agents_service_account
 
 targets:
   update-package-linux:


### PR DESCRIPTION
Backport of:
- https://github.com/jenkins-infra/release/pull/907
  - Includes JDK and Maven patches: https://github.com/jenkins-infra/docker-packaging/compare/9.1.12...9.1.19
- https://github.com/jenkins-infra/release/pull/910
  - Not strictly mandatory, added to get passing pipelines ✅ 

Other important PRs have already been backported (thanks @dduportal!):
- https://github.com/jenkins-infra/release/pull/908
- https://github.com/jenkins-infra/release/pull/912
- https://github.com/jenkins-infra/release/pull/916

Refs:
- https://github.com/jenkins-infra/helpdesk/issues/5161
- https://github.com/jenkins-infra/release/issues/902