### PR TITLE
Backport of `master` into `stable-2.555` for LTS 2.555.3 release

### DIFF
--- a/PodTemplates.d/package-linux.yaml
+++ b/PodTemplates.d/package-linux.yaml
@@ -10,7 +10,7 @@ spec:
   serviceAccountName: release-ci-jenkins-io-agents
   containers:
     - name: jnlp
-      image: jenkinsciinfra/packaging:9.1.12
+      image: jenkinsciinfra/packaging:9.1.19
       imagePullPolicy: "IfNotPresent"
       env:
         - name: "JENKINS_JAVA_BIN"

--- a/PodTemplates.d/package-windows.yaml
+++ b/PodTemplates.d/package-windows.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   serviceAccountName: release-ci-jenkins-io-agents
   containers:
-  - image: jenkins/inbound-agent:3355.v388858a_47b_33-18-jdk25-nanoserver-ltsc2022
+  - image: jenkins/inbound-agent:3355.v388858a_47b_33-21-jdk25-nanoserver-ltsc2022
     imagePullPolicy: "IfNotPresent"
     name: "jnlp"
     env:

--- a/PodTemplates.d/release-linux.yaml
+++ b/PodTemplates.d/release-linux.yaml
@@ -10,7 +10,7 @@ spec:
   serviceAccountName: release-ci-jenkins-io-agents
   containers:
     - name: jnlp
-      image: jenkinsciinfra/packaging:9.1.12
+      image: jenkinsciinfra/packaging:9.1.19
       imagePullPolicy: "IfNotPresent"
       env:
         - name: "HOME"


### PR DESCRIPTION
Same as #921 but in `stable-2.555` in case we need to publish a 2.555.4 release later.