### PR TITLE
cleanup: remove deprecated Azure Vault access with credentials (backport)

### DIFF
--- a/Jenkinsfile.d/core/package
+++ b/Jenkinsfile.d/core/package
@@ -86,10 +86,6 @@ pipeline {
 
   environment {
     AZURE_VAULT_NAME          = 'prodreleasecore'
-    AZURE_VAULT_CERT          = 'prodreleasecore-2023'
-    AZURE_VAULT_CLIENT_ID     = credentials('azure-vault-client-id')
-    AZURE_VAULT_CLIENT_SECRET = credentials('azure-vault-client-secret')
-    AZURE_VAULT_TENANT_ID     = credentials('azure-vault-tenant-id')
     GPG_FILE                  = 'jenkins-release.gpg'
     GPG_PASSPHRASE            = credentials('release-gpg-passphrase-2026')
     // Using HTTPS with no credentials - https://github.com/jenkins-infra/helpdesk/issues/4909 - need a GH app if rate limited or need to write things to git

--- a/Jenkinsfile.d/core/release
+++ b/Jenkinsfile.d/core/release
@@ -50,9 +50,6 @@ pipeline {
 
   environment {
     AZURE_VAULT_NAME              = 'prodreleasecore'
-    AZURE_VAULT_CLIENT_ID         = credentials('azure-vault-client-id')
-    AZURE_VAULT_CLIENT_SECRET     = credentials('azure-vault-client-secret')
-    AZURE_VAULT_TENANT_ID         = credentials('azure-vault-tenant-id')
     GPG_PASSPHRASE                = credentials('release-gpg-passphrase-2026')
     GPG_FILE                      = 'jenkins-release.gpg'
     MAVEN_REPOSITORY_USERNAME     = credentials('maven-repository-username')

--- a/Jenkinsfile.d/infra-agents-health
+++ b/Jenkinsfile.d/infra-agents-health
@@ -21,9 +21,6 @@ pipeline {
     RELEASE_PROFILE           = 'weekly'
     AZURE_VAULT_NAME          = 'prodreleasecore'
     GPG_FILE                  = 'jenkins-release.gpg'
-    AZURE_VAULT_CLIENT_ID     = credentials('azure-vault-client-id')
-    AZURE_VAULT_CLIENT_SECRET = credentials('azure-vault-client-secret')
-    AZURE_VAULT_TENANT_ID     = credentials('azure-vault-tenant-id')
     // Using HTTPS with no credentials - https://github.com/jenkins-infra/helpdesk/issues/4909 - need a GH app if rate limited or need to write things to git
     PACKAGING_GIT_REPOSITORY  = 'https://github.com/jenkinsci/packaging.git'
     PACKAGING_GIT_BRANCH      = 'master'

--- a/utils/release.bash
+++ b/utils/release.bash
@@ -9,12 +9,6 @@ function requireGPGPassphrase() {
 	: "${GPG_PASSPHRASE:?GPG Passphrase Required}" # Password must be the same for gpg agent and gpg key
 }
 
-function requireAzureKeyvaultCredentials() {
-	: "${AZURE_VAULT_CLIENT_ID:? Require AZURE_VAULT_CLIENT_ID}"
-	: "${AZURE_VAULT_CLIENT_SECRET:? Required AZURE_VAULT_CLIENT_SECRET}"
-	: "${AZURE_VAULT_TENANT_ID:? Required AZURE_VAULT_TENANT_ID}"
-}
-
 function clean() {
 	mvn -B -V -s settings-release.xml -ntp release:clean
 }
@@ -56,10 +50,7 @@ function configureGPG() {
 }
 
 function azureAccountAuth() {
-	az login --service-principal \
-		-u "${AZURE_VAULT_CLIENT_ID}" \
-		-p "${AZURE_VAULT_CLIENT_SECRET}" \
-		-t "${AZURE_VAULT_TENANT_ID}"
+	az login --federated-token "$(cat "$AZURE_FEDERATED_TOKEN_FILE")" --service-principal -u "$AZURE_CLIENT_ID" -t "$AZURE_TENANT_ID"
 }
 
 # Once the exact Jenkins Version to get is determined, we retrieve the WAR and the signature file from Artifactory
@@ -81,7 +72,6 @@ function downloadJenkinsWar() {
 }
 
 function getGPGKeyFromAzure() {
-	requireAzureKeyvaultCredentials
 	azureAccountAuth
 
 	az keyvault secret download \


### PR DESCRIPTION
Backport of #925, required as the pipeline would fail without it.

Other changes from `master` not in `stable-2.568` don't worth a backport as either concerning GitHub Actions, issue template or agent image bump not containing any required changes.

Refs:
- https://github.com/jenkins-infra/helpdesk/issues/5213
- #928 