### PR TITLE
Add infra-agents-health check to LTS release checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
@@ -94,6 +94,8 @@ The [documentation](https://github.com/jenkins-infra/release/blob/master/docs/re
 
 - [ ] Announce the start of the LTS release process in the [#jenkins-release:matrix.org](https://matrix.to/#/#jenkins-release:matrix.org) channel.
 
+- [ ] Trigger https://release.ci.jenkins.io/job/infra-agents-health/job/master to check that agents can be provisioned without issue and notify the Jenkins Infrastructure team if it's not passing
+
 - [ ] If this is the **first** release of a new LTS line (otherwise you can ignore this bullet), we have two pipelines which will fail on their first run on the `stable-xxx` branches. You have to run them both, only once for their first build (so they can parse their parameters) and cancel them after a few seconds (the button "Build" of the branch page should then change to "Build with Parameters" after reloading the page):
   - [ ] "Child" pipeline [https://release.ci.jenkins.io/job/core/job/release/](https://release.ci.jenkins.io/job/core/job/release/) on its `stable-xxx` branch.
   - [ ] "Child" pipeline [https://release.ci.jenkins.io/job/core/job/package/](https://release.ci.jenkins.io/job/core/job/package/) on its `stable-xxx` branch.


### PR DESCRIPTION
Having this could alleviate bad surprises like the one encountered during LTS 2.568.1 release, before starting the actual release job.

Issue encountered: no `releacilinux` node pool scale up, I had to setup additional "hotfix" templates using `Standard_D8ds_v7` instead of `Standard_D8ads_v7` to perform that release.

> <img width="1124" height="534" alt="image" src="https://github.com/user-attachments/assets/aaae4b2c-7452-4250-924e-aaebcae1f819" />


Ref:
- `#jenkins/release` thread https://matrix.to/#/!JlkqzpdEnsUUuVtjgE:matrix.org/$lkOMVn2agx2SK65OMhJQmrK4_sfN_hcEE42ZRnOHZXQ?via=matrix.org&via=gitter.im